### PR TITLE
#3 - Add in 'FromSymbol' to perform attribute data building from the target symbol

### DIFF
--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/ConstructorSourceGenerator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/ConstructorSourceGenerator.cs
@@ -155,11 +155,13 @@ internal static class ConstructorSourceGenerator
             .AppendLine()
             .AppendLine()
             .Append(
-                $"public static void WithAttributeData({builderType} builder, global::Microsoft.CodeAnalysis.AttributeData attributeData)"
+                $"public static void WithAttributeData({builderType} builder, global::Microsoft.CodeAnalysis.AttributeData attributeData, global::Microsoft.CodeAnalysis.ISymbol targetSymbol)"
             )
             .AppendLine()
             .Append('{')
             .Indent()
+            .AppendLine()
+            .Append("builder.ForSymbol(targetSymbol);")
             .AppendLine()
             .Append("foreach (var constructor in Constructors)")
             .AppendLine()

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/DataBuilderInterfaceSourceGenerator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/DataBuilderInterfaceSourceGenerator.cs
@@ -40,6 +40,11 @@ internal static class DataBuilderInterfaceSourceGenerator
         // Track generated method signatures to avoid duplicates
         var generatedSignatures = new HashSet<string>();
 
+        // Target ISymbol (where the attribute is located): void ForSymbol(ISymbol symbol)
+        generatedSignatures.Add("ForSymbol(ISymbol)");
+        builder.AppendLine()
+            .Append("void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);");
+
         // Constructor parameters: void With{PascalName}(TypedConstant constant)
         foreach (var param in group.UniqueParameters)
         {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.Constructor.g.cs
@@ -29,8 +29,9 @@ internal sealed class TestAttributeConstructor
         global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>[] parameters
     ) : base(typeParameters, parameters, TestAttributeNamedParameter.NamedParameters) { }
     
-    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData)
+    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData, global::Microsoft.CodeAnalysis.ISymbol targetSymbol)
     {
+        builder.ForSymbol(targetSymbol);
         foreach (var constructor in Constructors)
         {
             if (constructor.IsCalledBy(attributeData))

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.IDataBuilder.g.cs
@@ -7,6 +7,7 @@ namespace AttributeTests;
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {
+    void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);
     void WithName(global::Microsoft.CodeAnalysis.TypedConstant constant);
     void WithValue(global::Microsoft.CodeAnalysis.TypedConstant constant);
     void WithService(global::Microsoft.CodeAnalysis.ITypeSymbol symbol);

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.Constructor.g.cs
@@ -29,8 +29,9 @@ internal sealed class TestAttributeConstructor
         global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>[] parameters
     ) : base(parameters) { }
     
-    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData)
+    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData, global::Microsoft.CodeAnalysis.ISymbol targetSymbol)
     {
+        builder.ForSymbol(targetSymbol);
         foreach (var constructor in Constructors)
         {
             if (constructor.IsCalledBy(attributeData))

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.IDataBuilder.g.cs
@@ -7,6 +7,7 @@ namespace AttributeTests;
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {
+    void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);
     void WithName(global::Microsoft.CodeAnalysis.TypedConstant constant);
     void WithValue(global::Microsoft.CodeAnalysis.TypedConstant constant);
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.Constructor.g.cs
@@ -18,8 +18,9 @@ internal sealed class TestAttributeConstructor
         global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>[] parameters
     ) : base(parameters, TestAttributeNamedParameter.NamedParameters) { }
     
-    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData)
+    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData, global::Microsoft.CodeAnalysis.ISymbol targetSymbol)
     {
+        builder.ForSymbol(targetSymbol);
         foreach (var constructor in Constructors)
         {
             if (constructor.IsCalledBy(attributeData))

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.IDataBuilder.g.cs
@@ -7,6 +7,7 @@ namespace AttributeTests;
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {
+    void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);
     void WithFoo(global::Microsoft.CodeAnalysis.TypedConstant constant);
     void WithBar(global::Microsoft.CodeAnalysis.TypedConstant constant);
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.Constructor.g.cs
@@ -21,8 +21,9 @@ internal sealed class TestAttributeConstructor
         global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>[] parameters
     ) : base(parameters) { }
     
-    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData)
+    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData, global::Microsoft.CodeAnalysis.ISymbol targetSymbol)
     {
+        builder.ForSymbol(targetSymbol);
         foreach (var constructor in Constructors)
         {
             if (constructor.IsCalledBy(attributeData))

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.IDataBuilder.g.cs
@@ -7,6 +7,7 @@ namespace AttributeTests;
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {
+    void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);
     void WithName(global::Microsoft.CodeAnalysis.TypedConstant constant);
     void WithValue(global::Microsoft.CodeAnalysis.TypedConstant constant);
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.Constructor.g.cs
@@ -26,8 +26,9 @@ internal sealed class TestAttributeConstructor
         global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>[] parameters
     ) : base(typeParameters, parameters) { }
     
-    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData)
+    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData, global::Microsoft.CodeAnalysis.ISymbol targetSymbol)
     {
+        builder.ForSymbol(targetSymbol);
         foreach (var constructor in Constructors)
         {
             if (constructor.IsCalledBy(attributeData))

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.IDataBuilder.g.cs
@@ -7,6 +7,7 @@ namespace AttributeTests;
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {
+    void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);
     void WithService(global::Microsoft.CodeAnalysis.ITypeSymbol symbol);
     void WithImplementation(global::Microsoft.CodeAnalysis.ITypeSymbol symbol);
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.Constructor.g.cs
@@ -18,8 +18,9 @@ internal sealed class TestAttributeConstructor
         global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>[] parameters
     ) : base(parameters, TestAttributeNamedParameter.NamedParameters) { }
     
-    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData)
+    public static void WithAttributeData(ITestAttributeDataBuilder builder, global::Microsoft.CodeAnalysis.AttributeData attributeData, global::Microsoft.CodeAnalysis.ISymbol targetSymbol)
     {
+        builder.ForSymbol(targetSymbol);
         foreach (var constructor in Constructors)
         {
             if (constructor.IsCalledBy(attributeData))

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.IDataBuilder.g.cs
@@ -7,6 +7,7 @@ namespace AttributeTests;
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {
+    void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);
     void WithFoo(global::Microsoft.CodeAnalysis.TypedConstant constant);
     void WithBar(global::Microsoft.CodeAnalysis.TypedConstant constant);
 }


### PR DESCRIPTION
Adds in `void FromSymbol(ISymbol)` to the attribute data builder interface so steps, such as fetching all enum values, constructors, properties, etc. can be done in this step.

Closes #3