### PR TITLE
#12 - Add Embedded to emitted types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Available on NuGet for .NET Standard 2.0:
 
 ```xml
 <PackageReference Include="ZCrew.Extensions.CodeAnalysis.CSharp">
-    <OutputItemType>Analyzer</OutputItemType>
+    <PrivateAssets>analyzers</PrivateAssets>
 </PackageReference>
 ```
 

--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -7,8 +7,7 @@ Add the NuGet package to your source generator project. Since this is an analyze
 ```xml
 <ItemGroup>
     <PackageReference Include="ZCrew.Extensions.CodeAnalysis.CSharp">
-        <OutputItemType>Analyzer</OutputItemType>
-        <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+        <PrivateAssets>analyzers</PrivateAssets>
     </PackageReference>
 </ItemGroup>
 ```

--- a/docs/3-emitting-attributes.md
+++ b/docs/3-emitting-attributes.md
@@ -46,6 +46,7 @@ This produces the following generated files (in the `MyGenerator` namespace).
 
 namespace MyGenerator;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface IRegisterDataBuilder
 {
@@ -72,6 +73,7 @@ Each constructor parameter gets a static instance that knows its type and how to
 
 namespace MyGenerator;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal class RegisterParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<IRegisterDataBuilder>
@@ -99,6 +101,7 @@ Each generic type parameter gets a static instance that delegates to the builder
 
 namespace MyGenerator;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class RegisterTypeParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeTypeParameter<IRegisterDataBuilder>
@@ -127,6 +130,7 @@ Each settable property gets a static instance. The instances are also collected 
 
 namespace MyGenerator;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class RegisterNamedParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeNamedParameter<IRegisterDataBuilder>
@@ -159,6 +163,7 @@ The `RegisterConstructor` ties everything together. It references the static ins
 
 namespace MyGenerator;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class RegisterConstructor
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeConstructor<IRegisterDataBuilder>

--- a/docs/4-emitting-other-abstractions.md
+++ b/docs/4-emitting-other-abstractions.md
@@ -32,6 +32,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace MyGenerator;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class ServiceLifetimeSourceText
 {

--- a/docs/5-formatted-string-builder.md
+++ b/docs/5-formatted-string-builder.md
@@ -108,6 +108,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace MyNamespace;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("MyGenerator", "0.0.0.0")]
 internal static class FooSourceText
 {

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/ConstructorSourceGenerator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/ConstructorSourceGenerator.cs
@@ -35,6 +35,7 @@ internal static class ConstructorSourceGenerator
             .AppendLine()
             .AppendFileScopedNamespaceDeclaration(group.Namespace)
             .AppendLine()
+            .AppendEmbeddedAttribute()
             .AppendGeneratedAttribute(GeneratorAssemblyName)
             .Append($"internal sealed class {baseName}Constructor")
             .AppendLine()

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/DataBuilderInterfaceSourceGenerator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/DataBuilderInterfaceSourceGenerator.cs
@@ -31,6 +31,7 @@ internal static class DataBuilderInterfaceSourceGenerator
             .AppendLine()
             .AppendFileScopedNamespaceDeclaration(group.Namespace)
             .AppendLine()
+            .AppendEmbeddedAttribute()
             .AppendGeneratedAttribute(GeneratorAssemblyName)
             .Append($"internal interface I{group.BaseName}DataBuilder")
             .AppendLine()
@@ -42,8 +43,7 @@ internal static class DataBuilderInterfaceSourceGenerator
 
         // Target ISymbol (where the attribute is located): void ForSymbol(ISymbol symbol)
         generatedSignatures.Add("ForSymbol(ISymbol)");
-        builder.AppendLine()
-            .Append("void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);");
+        builder.AppendLine().Append("void ForSymbol(global::Microsoft.CodeAnalysis.ISymbol symbol);");
 
         // Constructor parameters: void With{PascalName}(TypedConstant constant)
         foreach (var param in group.UniqueParameters)

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/NamedParameterSourceGenerator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/NamedParameterSourceGenerator.cs
@@ -33,6 +33,7 @@ internal static class NamedParameterSourceGenerator
             .AppendLine()
             .AppendFileScopedNamespaceDeclaration(group.Namespace)
             .AppendLine()
+            .AppendEmbeddedAttribute()
             .AppendGeneratedAttribute(GeneratorAssemblyName)
             .Append($"internal sealed class {baseName}NamedParameter")
             .AppendLine()

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/ParameterSourceGenerator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/ParameterSourceGenerator.cs
@@ -33,6 +33,7 @@ internal static class ParameterSourceGenerator
             .AppendLine()
             .AppendFileScopedNamespaceDeclaration(group.Namespace)
             .AppendLine()
+            .AppendEmbeddedAttribute()
             .AppendGeneratedAttribute(GeneratorAssemblyName)
             .Append($"internal class {baseName}Parameter")
             .AppendLine()

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/SourceTextSourceGenerator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/SourceTextSourceGenerator.cs
@@ -39,6 +39,7 @@ internal static class SourceTextSourceGenerator
             .AppendLine()
             .AppendFileScopedNamespaceDeclaration(group.Namespace)
             .AppendLine()
+            .AppendEmbeddedAttribute()
             .AppendGeneratedAttribute(GeneratorAssemblyName)
             .Append($"internal static class {group.BaseName}SourceText")
             .AppendLine()

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/TypeParameterSourceGenerator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/EmbeddedAttribute/SourceGenerators/TypeParameterSourceGenerator.cs
@@ -33,6 +33,7 @@ internal static class TypeParameterSourceGenerator
             .AppendLine()
             .AppendFileScopedNamespaceDeclaration(group.Namespace)
             .AppendLine()
+            .AppendEmbeddedAttribute()
             .AppendGeneratedAttribute(GeneratorAssemblyName)
             .Append($"internal sealed class {baseName}TypeParameter")
             .AppendLine()

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/Text/FormattedStringBuilderExtensions.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/Text/FormattedStringBuilderExtensions.cs
@@ -72,6 +72,15 @@ public static class FormattedStringBuilderExtensions
         }
 
         /// <summary>
+        ///     Appends a <c>EmbeddedAttribute</c> to a class.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        public FormattedStringBuilder AppendEmbeddedAttribute()
+        {
+            return builder.AppendLine("[global::Microsoft.CodeAnalysis.Embedded]");
+        }
+
+        /// <summary>
         ///     Appends a <see langword="typeof"/> expression with opening and closing round brackets.
         /// </summary>
         /// <param name="typeName">The name of the type.</param>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.Constructor.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeConstructor
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeConstructor<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.IDataBuilder.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.NamedParameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.NamedParameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeNamedParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeNamedParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.Parameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.Parameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal class TestAttributeParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.SourceText.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.SourceText.g.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class TestAttributeSourceText
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.TypeParameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/All.TypeParameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeTypeParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeTypeParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.Constructor.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeConstructor
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeConstructor<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.IDataBuilder.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.Parameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.Parameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal class TestAttributeParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.SourceText.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleConstructors.SourceText.g.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class TestAttributeSourceText
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.Constructor.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeConstructor
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeConstructor<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.IDataBuilder.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.NamedParameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.NamedParameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeNamedParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeNamedParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.SourceText.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleNamedParameters.SourceText.g.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class TestAttributeSourceText
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.Constructor.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeConstructor
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeConstructor<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.IDataBuilder.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.Parameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.Parameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal class TestAttributeParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.SourceText.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleParameters.SourceText.g.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class TestAttributeSourceText
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.Constructor.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeConstructor
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeConstructor<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.IDataBuilder.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.SourceText.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.SourceText.g.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class TestAttributeSourceText
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.TypeParameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/TestCases/MultipleTypeParameters.TypeParameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeTypeParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeTypeParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/SingleEnum.SourceText.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/SingleEnum.SourceText.g.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace CacheTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class TestEnumSourceText
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.Constructor.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.Constructor.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeConstructor
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeConstructor<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.IDataBuilder.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.IDataBuilder.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal interface ITestAttributeDataBuilder
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.NamedParameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.NamedParameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeNamedParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeNamedParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.Parameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.Parameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeNamedParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeNamedParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.SourceText.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.SourceText.g.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class TestAttributeSourceText
 {

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.TypeParameter.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/WithAttribute.TypeParameter.g.cs
@@ -4,6 +4,7 @@
 
 namespace AttributeTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal sealed class TestAttributeNamedParameter
     : global::ZCrew.Extensions.CodeAnalysis.CSharp.AttributeNamedParameter<ITestAttributeDataBuilder>

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/EnumTests/TestCases/SingleEnum.SourceText.g.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/EnumTests/TestCases/SingleEnum.SourceText.g.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace EnumTests;
 
+[global::Microsoft.CodeAnalysis.Embedded]
 [global::System.CodeDom.Compiler.GeneratedCode("ZCrew.Extensions.CodeAnalysis.CSharp", "0.0.0.0")]
 internal static class TestEnumSourceText
 {


### PR DESCRIPTION
The attribute data builder types are meant only for the project directly using the source generator. These can be set at `Embedded` to avoid leaking the types via `InternalVisibleTo`.

Closes #12