### PR TITLE
#21 - Fix issues with partial declaration helpers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,7 +63,17 @@ dotnet_naming_symbols.constant_fields.applicable_kinds = field
 dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-# static fields should have s_ prefix
+# name all static readonly fields using PascalCase
+dotnet_naming_rule.static_readonly_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_readonly_fields_should_have_prefix.symbols = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_should_have_prefix.style = static_readonly_prefix_style
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static,readonly
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_readonly_prefix_style.required_prefix =
+dotnet_naming_style.static_readonly_prefix_style.capitalization = pascal_case
+
+# name all static fields using camelCase
 dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
 dotnet_naming_rule.static_fields_should_have_prefix.symbols = static_fields
 dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
@@ -73,14 +83,14 @@ dotnet_naming_symbols.static_fields.applicable_accessibilities = private, intern
 dotnet_naming_style.static_prefix_style.required_prefix =
 dotnet_naming_style.static_prefix_style.capitalization = camel_case
 
-# internal and private fields should be _camelCase
+# name all internal and private fields using camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix =
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+dotnet_naming_style.camel_case_style.required_prefix =
+dotnet_naming_style.camel_case_style.capitalization = camel_case
 
 # Code style defaults
 csharp_using_directive_placement = outside_namespace:suggestion
@@ -154,11 +164,6 @@ csharp_space_between_method_declaration_name_and_open_parenthesis = false
 csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
-
-# Generated files
-[*.g.cs]
-csharp_remove_spaces_on_blank_lines = false
-trim_trailing_whitespace = false
 
 # Solution files
 [*.slnx]

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/IsType/IsTypeMethodInfoFactory.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/IsType/IsTypeMethodInfoFactory.cs
@@ -244,7 +244,7 @@ internal static class IsTypeMethodInfoFactory
 
         for (var current = method.ContainingType; current is not null; current = current.ContainingType)
         {
-            declarations.Add(current.ToPartialClassDeclaration());
+            declarations.Add(current.ToPartialTypeDeclaration());
             names.Add(current.Name);
         }
 

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/SymbolExtensions.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/SymbolExtensions.cs
@@ -33,15 +33,21 @@ public static class SymbolExtensions
         parameterOptions: SymbolDisplayParameterOptions.IncludeExtensionThis
             | SymbolDisplayParameterOptions.IncludeModifiers
             | SymbolDisplayParameterOptions.IncludeType
-            | SymbolDisplayParameterOptions.IncludeName
-            | SymbolDisplayParameterOptions.IncludeDefaultValue,
-        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+            | SymbolDisplayParameterOptions.IncludeName,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes
+            | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
+            | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
     );
 
     private static readonly SymbolDisplayFormat classDeclarationFormat = new(
         globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
         typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
-        kindOptions: SymbolDisplayKindOptions.IncludeTypeKeyword
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters
+            | SymbolDisplayGenericsOptions.IncludeVariance,
+        kindOptions: SymbolDisplayKindOptions.IncludeTypeKeyword,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes
+            | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
+            | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
     );
 
     extension(ISymbol symbol)
@@ -155,7 +161,7 @@ public static class SymbolExtensions
         ///         public static partial void Print(global::System.Collections.Generic.IEnumerable values)
         ///     </code>
         /// </example>
-        internal string ToPartialMethodDeclaration()
+        public string ToPartialMethodDeclaration()
         {
             var stringBuilder = new StringBuilder();
 
@@ -168,21 +174,23 @@ public static class SymbolExtensions
             stringBuilder.Append("partial ");
 
             // Add the method name, parameters, constraints, etc.
-            stringBuilder.Append(symbol.ToDisplayString());
+            stringBuilder.Append(symbol.ToDisplayString(methodDeclarationPostPartialFormat));
             return stringBuilder.ToString();
         }
 
         /// <summary>
-        ///     Generates a single-line partial class declaration used to provide a partial class part. Accessibility,
-        ///     modifiers, generic types, and generic type constraints are not included as they are not necessary.
+        ///     Generates a single-line partial type declaration used to provide a partial type part. This is meant for
+        ///     <see langword="class"/>, <see langword="record"/>, <see langword="struct"/> and
+        ///     <see langword="interface"/> types. Accessibility, modifiers and generic type constraints are not
+        ///     included as they are not necessary.
         /// </summary>
-        /// <returns>The partial class declaration.</returns>
+        /// <returns>The partial type declaration.</returns>
         /// <example>
         ///     <code>
         ///         partial class EnumerableExtensions
         ///     </code>
         /// </example>
-        internal string ToPartialClassDeclaration()
+        public string ToPartialTypeDeclaration()
         {
             var stringBuilder = new StringBuilder();
 

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/Text/StringBuilderExtensions.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/Text/StringBuilderExtensions.cs
@@ -38,14 +38,21 @@ public static class StringBuilderExtensions
         /// <returns></returns>
         public StringBuilder AppendMemberModifiers(ISymbol symbol)
         {
+            // Emit in the canonical C# modifier order (see StyleCop SA1206 / IDE0036):
+            // static extern new virtual abstract sealed override.
             if (symbol.IsStatic)
             {
                 builder.Append("static ");
             }
 
-            if (symbol.IsOverride)
+            if (symbol.IsExtern)
             {
-                builder.Append("override ");
+                builder.Append("extern ");
+            }
+
+            if (symbol.IsVirtual)
+            {
+                builder.Append("virtual ");
             }
 
             if (symbol.IsAbstract)
@@ -58,14 +65,9 @@ public static class StringBuilderExtensions
                 builder.Append("sealed ");
             }
 
-            if (symbol.IsExtern)
+            if (symbol.IsOverride)
             {
-                builder.Append("extern ");
-            }
-
-            if (symbol.IsVirtual)
-            {
-                builder.Append("virtual ");
+                builder.Append("override ");
             }
 
             return builder;

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests/SymbolExtensionsTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests/SymbolExtensionsTests.cs
@@ -1,0 +1,532 @@
+using Microsoft.CodeAnalysis;
+using ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests.TestHelpers;
+
+namespace ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests;
+
+public class SymbolExtensionsTests
+{
+    [Fact]
+    public void ToPartialTypeDeclaration_ForClass_IncludesClassKeyword()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public class Foo { }", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial class Foo", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForInterface_IncludesInterfaceKeyword()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public interface IFoo { }", "IFoo");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial interface IFoo", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForRecord_IncludesRecordKeyword()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public record Foo { }", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial record Foo", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForRecordStruct_IncludesRecordStructKeyword()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public record struct Foo { }", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial record struct Foo", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForStruct_IncludesStructKeyword()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public struct Foo { }", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial struct Foo", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForGenericType_IncludesTypeParameters()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public class Foo<T> { }", "Foo`1");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial class Foo<T>", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForTypeWithMultipleTypeParameters_IncludesAllTypeParameters()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public class Foo<TKey, TValue> { }", "Foo`2");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial class Foo<TKey, TValue>", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForCovariantInterface_IncludesOutVariance()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public interface IFoo<out T> { }", "IFoo`1");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial interface IFoo<out T>", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForContravariantInterface_IncludesInVariance()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public interface IFoo<in T> { }", "IFoo`1");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial interface IFoo<in T>", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForNestedType_OmitsContainingType()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public class Outer { public class Inner { } }", "Outer+Inner");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial class Inner", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForNamespacedType_OmitsNamespace()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("namespace N { public class Foo { } }", "N.Foo");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial class Foo", declaration);
+    }
+
+    [Fact]
+    public void ToPartialTypeDeclaration_ForKeywordNamedType_EscapesIdentifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetType("public class @class { }", "class");
+
+        // Act
+        var declaration = symbol.ToPartialTypeDeclaration();
+
+        // Assert
+        Assert.Equal("partial class @class", declaration);
+    }
+
+    [Theory]
+    [InlineData("public", "public partial void Foo()")]
+    [InlineData("private", "private partial void Foo()")]
+    [InlineData("internal", "internal partial void Foo()")]
+    [InlineData("protected", "protected partial void Foo()")]
+    [InlineData("protected internal", "protected internal partial void Foo()")]
+    [InlineData("private protected", "private protected partial void Foo()")]
+    public void ToPartialMethodDeclaration_ForEachAccessibility_PrependsAccessibility(
+        string accessibility,
+        string expected
+    )
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            $$"""public class C { {{accessibility}} void Foo() { } }""",
+            "C",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal(expected, declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForStaticMethod_IncludesStaticModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public static void Foo() { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public static partial void Foo()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForVirtualMethod_IncludesVirtualModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public virtual void Foo() { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public virtual partial void Foo()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForOverrideMethod_IncludesOverrideModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            """
+            public class Base { public virtual void Foo() { } }
+            public class Derived : Base { public override void Foo() { } }
+            """,
+            "Derived",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public override partial void Foo()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForAbstractMethod_IncludesAbstractModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public abstract class C { public abstract void Foo(); }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public abstract partial void Foo()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForSealedOverrideMethod_IncludesOverrideAndSealedModifiers()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            """
+            public class Base { public virtual void Foo() { } }
+            public class Derived : Base { public sealed override void Foo() { } }
+            """,
+            "Derived",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public sealed override partial void Foo()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForExternMethod_IncludesExternModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public static extern void Foo(); }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public static extern partial void Foo()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForNonVoidMethod_IncludesReturnType()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("""public class C { public string Foo() => ""; }""", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial string Foo()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForRefReturningMethod_IncludesRefModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            "public class C { private int field; public ref int Foo() => ref field; }",
+            "C",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial ref int Foo()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForMethodWithParameter_IncludesParameterTypeAndName()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public void Foo(int value) { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo(int value)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForRefParameter_IncludesRefModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public void Foo(ref int value) { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo(ref int value)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForOutParameter_IncludesOutModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            "public class C { public void Foo(out int value) { value = 0; } }",
+            "C",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo(out int value)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForInParameter_IncludesInModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public void Foo(in int value) { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo(in int value)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForParamsParameter_IncludesParamsModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            "public class C { public void Foo(params int[] values) { } }",
+            "C",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo(params int[] values)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForExtensionMethod_IncludesThisModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            "public static class Extensions { public static void Foo(this int value) { } }",
+            "Extensions",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public static partial void Foo(this int value)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForGenericMethod_IncludesTypeParameters()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public void Foo<T>(T value) { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo<T>(T value)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForConstrainedGenericMethod_IncludesTypeConstraints()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            "public class C { public void Foo<T>(T value) where T : class { } }",
+            "C",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo<T>(T value) where T : class", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForExplicitInterfaceImplementation_IncludesInterfaceQualifier()
+    {
+        // Arrange
+        var type = RoslynTestHelper.GetType(
+            """
+            namespace N
+            {
+                public interface IFoo { void Bar(); }
+                public class C : IFoo { void IFoo.Bar() { } }
+            }
+            """,
+            "N.C"
+        );
+        var symbol = type.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Single(method => method.MethodKind == MethodKind.ExplicitInterfaceImplementation);
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("private partial void global::N.IFoo.Bar()", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForNamespacedParameterType_IncludesGlobalQualifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            "public class C { public void Foo(System.Collections.Generic.IEnumerable<int> values) { } }",
+            "C",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal(
+            "public partial void Foo(global::System.Collections.Generic.IEnumerable<int> values)",
+            declaration
+        );
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForFrameworkTypes_UsesSpecialTypeKeywords()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod(
+            "public class C { public System.Int32 Foo(System.String value) => 0; }",
+            "C",
+            "Foo"
+        );
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial int Foo(string value)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForKeywordNamedParameter_EscapesIdentifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public void Foo(int @int) { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo(int @int)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForNullableReferenceParameter_IncludesNullableModifier()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public void Foo(string? value) { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo(string? value)", declaration);
+    }
+
+    [Fact]
+    public void ToPartialMethodDeclaration_ForParameterWithDefaultValue_OmitsDefaultValue()
+    {
+        // Arrange
+        var symbol = RoslynTestHelper.GetMethod("public class C { public void Foo(int value = 5) { } }", "C", "Foo");
+
+        // Act
+        var declaration = symbol.ToPartialMethodDeclaration();
+
+        // Assert
+        Assert.Equal("public partial void Foo(int value)", declaration);
+    }
+}

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests/TestHelpers/RoslynTestHelper.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests/TestHelpers/RoslynTestHelper.cs
@@ -1,0 +1,75 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests.TestHelpers;
+
+/// <summary>
+///     Compiles C# source snippets into Roslyn symbols so that <see cref="SymbolExtensions"/> can be exercised
+///     against real <see cref="ISymbol"/> instances.
+/// </summary>
+internal static class RoslynTestHelper
+{
+    private static readonly MetadataReference[] References = (
+        (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!
+    )
+        .Split(Path.PathSeparator)
+        .Where(path => path.Length > 0)
+        .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+        .ToArray();
+
+    /// <summary>
+    ///     Compiles <paramref name="source"/> with nullable reference types enabled and asserts that it produced no
+    ///     compiler errors, so any symbols pulled from it are trustworthy.
+    /// </summary>
+    /// <param name="source">The C# source to compile.</param>
+    /// <returns>The resulting compilation.</returns>
+    public static CSharpCompilation Compile(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+
+        var compilation = CSharpCompilation.Create(
+            "SymbolExtensionsTests",
+            [syntaxTree],
+            References,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable
+            )
+        );
+
+        var errors = compilation
+            .GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        Assert.Empty(errors);
+
+        return compilation;
+    }
+
+    /// <summary>
+    ///     Compiles <paramref name="source"/> and returns the named type symbol.
+    /// </summary>
+    /// <param name="source">The C# source to compile.</param>
+    /// <param name="fullyQualifiedMetadataName">The metadata name of the type, e.g. <c>"N.Outer+Inner"</c>.</param>
+    /// <returns>The named type symbol.</returns>
+    public static INamedTypeSymbol GetType(string source, string fullyQualifiedMetadataName)
+    {
+        var compilation = Compile(source);
+        var symbol = compilation.GetTypeByMetadataName(fullyQualifiedMetadataName);
+        Assert.NotNull(symbol);
+        return symbol;
+    }
+
+    /// <summary>
+    ///     Compiles <paramref name="source"/> and returns the single method with the given name on the given type.
+    /// </summary>
+    /// <param name="source">The C# source to compile.</param>
+    /// <param name="fullyQualifiedTypeName">The metadata name of the declaring type.</param>
+    /// <param name="methodName">The method name.</param>
+    /// <returns>The method symbol.</returns>
+    public static IMethodSymbol GetMethod(string source, string fullyQualifiedTypeName, string methodName)
+    {
+        var type = GetType(source, fullyQualifiedTypeName);
+        return type.GetMembers(methodName).OfType<IMethodSymbol>().Single();
+    }
+}


### PR DESCRIPTION
Fixes some issues I found with the partial declaration helpers:

- The method was outputting the wrong order of modifiers
- The method was missing special type helpers, name escaping
- The class was missing type parameters
- Both were internal but now are tested and working as expected so they have been made public again

Closes #21