### PR TITLE
#22 - Add AppendMultiline

### DIFF
--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/Text/FormattedStringBuilderExtensions.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/Text/FormattedStringBuilderExtensions.cs
@@ -137,5 +137,53 @@ public static class FormattedStringBuilderExtensions
             builder.Append("\"\"\"");
             return builder;
         }
+
+        /// <summary>
+        ///     Appends a multiline <see cref="string"/>.
+        /// </summary>
+        /// <param name="lines">The multiline string to write.</param>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private const string Comment =
+        ///         """
+        ///         /// <summary>
+        ///         /// Generated method for registering a component.
+        ///         /// </summary>
+        ///         """;
+        ///     private string comment = new FormattedStringBuilder()
+        ///         .Append('{')
+        ///         .Indent()
+        ///         .AppendLine()
+        ///         .AppendMultiline(Comment)
+        ///         .Append("public void Register() {}")
+        ///         .Unindent()
+        ///         .AppendLine()
+        ///         .Append('}');
+        /// </code>
+        /// Would generate:
+        /// <code>
+        ///     {
+        ///         /// <summary>
+        ///         /// Generated method for registering a component.
+        ///         /// </summary>
+        ///         public void Register() {}
+        ///     }
+        /// </code>
+        /// </example>
+        /// <remarks>
+        ///     This may be useful when emitting XML comments where the comment is static and should be readable in the
+        ///     source code.
+        /// </remarks>
+        public FormattedStringBuilder AppendMultiline(string lines)
+        {
+            // Normalize to the builder's own newlines
+            foreach (var line in lines.Split(["\r\n", "\n"], StringSplitOptions.None))
+            {
+                builder.AppendLine(line);
+            }
+
+            return builder;
+        }
     }
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests/Text/FormattedStringBuilderExtensionsTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests/Text/FormattedStringBuilderExtensionsTests.cs
@@ -103,4 +103,90 @@ public class FormattedStringBuilderExtensionsTests
             """;
         Assert.Equal(expectedString, formattedStringBuilder.ToString());
     }
+
+    [Theory]
+    [InlineData("first\nsecond\nthird")]
+    [InlineData("first\r\nsecond\r\nthird")]
+    [InlineData("first\nsecond\r\nthird")]
+    public void AppendMultiline_WhenCalledWithDifferentLineEndings_ShouldNormalizeToBuilderNewlines(string lines)
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+
+        // Act
+        formattedStringBuilder.AppendMultiline(lines);
+
+        // Assert
+        var expectedString = """
+            first
+            second
+            third
+
+            """;
+        Assert.Equal(expectedString, formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendMultiline_WhenCalledWithSingleLine_ShouldAppendLineWithTerminator()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+
+        // Act
+        formattedStringBuilder.AppendMultiline("only");
+
+        // Assert
+        var expectedString = """
+            only
+
+            """;
+        Assert.Equal(expectedString, formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendMultiline_WhenCalled_ShouldReturnSameBuilder()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+
+        // Act
+        var result = formattedStringBuilder.AppendMultiline("line");
+
+        // Assert
+        Assert.Same(formattedStringBuilder, result);
+    }
+
+    [Fact]
+    public void AppendMultiline_WhenBuilderIsIndented_ShouldIndentEachAppendedLine()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        var comment = """
+            /// <summary>
+            /// Generated method for registering a component.
+            /// </summary>
+            """;
+
+        // Act
+        formattedStringBuilder
+            .Append('{')
+            .Indent()
+            .AppendLine()
+            .AppendMultiline(comment)
+            .Append("public void Register() { }")
+            .Unindent()
+            .AppendLine()
+            .Append('}');
+
+        // Assert
+        var expectedString = """
+            {
+                /// <summary>
+                /// Generated method for registering a component.
+                /// </summary>
+                public void Register() { }
+            }
+            """;
+        Assert.Equal(expectedString, formattedStringBuilder.ToString());
+    }
 }


### PR DESCRIPTION
Adds `AppendMultiline` for appending multiline strings with proper indents. This is most useful for large static chunks of code like comments or boilerplate.

Closes #22