### PR TITLE
#26 - Add in test generation

### DIFF
--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/GeneratorActivator.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/GeneratorActivator.cs
@@ -1,0 +1,36 @@
+using Microsoft.CodeAnalysis;
+
+namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
+
+/// <summary>
+///     Instantiates a source generator type and adapts it to <see cref="ISourceGenerator" />.
+/// </summary>
+internal static class GeneratorActivator
+{
+    /// <summary>
+    ///     Creates a new instance of <typeparamref name="TGenerator" /> and returns it as an
+    ///     <see cref="ISourceGenerator" />, wrapping an <see cref="IIncrementalGenerator" /> via
+    ///     <see cref="GeneratorExtensions.AsSourceGenerator" />.
+    /// </summary>
+    /// <typeparam name="TGenerator">
+    ///     The generator type. Must be an <see cref="IIncrementalGenerator" /> or <see cref="ISourceGenerator" />
+    ///     with a public parameterless constructor.
+    /// </typeparam>
+    /// <returns>The generator instance as an <see cref="ISourceGenerator" />.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when <typeparamref name="TGenerator" /> is neither an <see cref="IIncrementalGenerator" /> nor an
+    ///     <see cref="ISourceGenerator" />.
+    /// </exception>
+    public static ISourceGenerator CreateSourceGenerator<TGenerator>()
+        where TGenerator : new()
+    {
+        return new TGenerator() switch
+        {
+            IIncrementalGenerator incremental => incremental.AsSourceGenerator(),
+            ISourceGenerator source => source,
+            var other => throw new InvalidOperationException(
+                $"'{other!.GetType()}' is neither an IIncrementalGenerator nor an ISourceGenerator."
+            ),
+        };
+    }
+}

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/GeneratorPostInitializationSources.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/GeneratorPostInitializationSources.cs
@@ -13,7 +13,7 @@ internal static class GeneratorPostInitializationSources<TGenerator>
     where TGenerator : new()
 {
     // ReSharper disable once StaticMemberInGenericType - this is meant to be scoped per generator type
-    private static readonly Lazy<ImmutableArray<(string HintName, SourceText Content)>> lazySources = new(
+    private static readonly Lazy<ImmutableArray<(string HintName, SourceText Content)>> LazySources = new(
         Capture,
         LazyThreadSafetyMode.ExecutionAndPublication
     );
@@ -22,7 +22,7 @@ internal static class GeneratorPostInitializationSources<TGenerator>
     ///     The sources a generator emits using <see cref="IncrementalGeneratorPostInitializationContext"/>. These are
     ///     typically static (unchanged from run-to-run) and can be cached here for most generators.
     /// </summary>
-    public static ImmutableArray<(string HintName, SourceText Content)> Sources => lazySources.Value;
+    public static ImmutableArray<(string HintName, SourceText Content)> Sources => LazySources.Value;
 
     private static ImmutableArray<(string HintName, SourceText Content)> Capture()
     {
@@ -42,6 +42,6 @@ internal static class GeneratorPostInitializationSources<TGenerator>
         );
 
         var runResult = CSharpGeneratorDriver.Create(generator).RunGenerators(compilation).GetRunResult();
-        return runResult.Results[0].GeneratedSources.Select(s => (s.HintName, s.SourceText)).ToImmutableArray();
+        return [.. runResult.Results[0].GeneratedSources.Select(s => (s.HintName, s.SourceText))];
     }
 }

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/README.md
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/README.md
@@ -1,6 +1,8 @@
-# ZCrew.Extensions.CodeAnalysis.CSharp
+# ZCrew.Extensions.CodeAnalysis.CSharp.Testing
 
-Testing library for verifying Roslyn source generators.
+Testing library for verifying Roslyn source generators. It drives a generator through Roslyn's
+`CSharpSourceGeneratorTest` harness from a small JSON descriptor, so each test case is just a set of input and
+expected-output files plus a `.json` that ties them together.
 
 ## Installation
 
@@ -9,3 +11,91 @@ Available on NuGet for .NET Standard 2.0:
 ```xml
 <PackageReference Include="ZCrew.Extensions.CodeAnalysis.CSharp.Testing" />
 ```
+
+## Writing a test case
+
+A test case is three kinds of file in a `TestCases/` folder next to your test class:
+
+- **Input sources** (e.g. `MyCase.Attribute.cs`) compiled as input to the generator.
+- **Expected generated files** (e.g. `MyCase.SourceText.g.cs`) the output to verify against.
+- **A JSON descriptor** (`MyCase.json`) maps the inputs and expected outputs (diagnostics coming soon(tm)):
+
+```json
+{
+    "SourceFiles": [
+        { "SourceFileName": "MyCase.Attribute.cs" }
+    ],
+    "GeneratedFiles": [
+        {
+            "SourceFileName": "MyCase.SourceText.g.cs",
+            "GeneratedFileName": "MyNamespace.MyTypeSourceText.g.cs"
+        }
+    ]
+}
+```
+
+`SourceFileName` is the file on disk; `GeneratedFileName` is the **hint name** your generator passes to
+`context.AddSource(hintName, ...)`.
+
+## Wiring the test
+
+Configure a shared baseline once, then load and run each case. Resolve the `TestCases` folder from the source
+tree with `TestPath.ForCaller()` so fixtures are checked into git:
+
+```csharp
+private static readonly SourceGeneratorTestBuilder<MyGenerator, DefaultVerifier> Baseline =
+    SourceGeneratorTestBuilder<MyGenerator>
+        .CreateDefaultBuilder()
+        .WithReferenceAssemblies(ReferenceAssemblies.Net.Net100)
+        .WithGeneratorPostInitializationSources();
+
+private static readonly TestPath testCases = TestPath.ForCaller() / "TestCases";
+
+[Theory]
+[InlineData("MyCase.json")]
+public async Task Generates_expected_sources(string descriptor)
+{
+    var testCase = await JsonTestCase.FromJsonFileAsync(testCases / descriptor);
+    var test = await Baseline.BuildAsync(testCase);
+    await test.RunAsync();
+}
+```
+
+The builder is immutable (every `With*` call forks a new builder) so a fully configured baseline can be shared
+as a fixture and specialized per test without affecting other tests.
+
+## Project setup
+
+Keep fixture files out of the compilation and out of the build output. Because the test resolves them from the
+source tree via `TestPath.ForCaller()`, they do not need to be copied to `bin`:
+
+```xml
+<ItemGroup>
+  <!-- These end in .cs for editor hints but must not be compiled. -->
+  <Compile Remove="**/TestCases/**/*.cs" />
+  <!-- Included for editor visibility/nesting only; not copied to the output directory. -->
+  <None Include="**/TestCases/**/*.json" Exclude="bin/**/*.json" />
+  <None Include="**/TestCases/**/*.cs" Exclude="bin/**/*.cs" />
+</ItemGroup>
+```
+
+## Updating expected files in place
+
+Hand-writing and maintaining `.g.cs` files is tedious and I hate it, you should too. Add `WithExpectedSourceUpdates()`
+to the baseline and, whenever the generator's output differs from (or is missing) an expected file, the test
+**overwrites it on disk with the produced output and still fails**:
+
+```csharp
+.WithExpectedSourceUpdates(enabled: Environment.GetEnvironmentVariable("CI") is null)
+```
+
+Workflow:
+
+1. Change your generator, or add a new test case whose `.g.cs` files do not exist yet.
+2. Run the tests. Mismatched and missing expected files are rewritten in place and the run is **red**.
+3. Review the changes in source control
+4. Keep them (re-run → green) or revert them.
+
+The tests compare the output to previous file contents, so this won't cause false-positives. This does mean that when
+you get a failure and you've fixed it: the next test will fail (the previous file contents were broken and the new ones
+are fixed), and so running the tests again will then pass.

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/SourceGeneratorTestBuilder.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/SourceGeneratorTestBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -85,6 +86,7 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
         SourceText Content
     )>.Empty;
     private bool includePostInitializationSources;
+    private bool updateExpectedSources;
     private ImmutableList<Func<string, string>> contentTransforms = ImmutableList<Func<string, string>>.Empty;
     private ImmutableList<Action<CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>>> configurations =
         ImmutableList<Action<CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>>>.Empty;
@@ -248,6 +250,26 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
     }
 
     /// <summary>
+    ///     Enables in-place updates of the expected generated files. When enabled, <see cref="BuildAsync" /> runs the
+    ///     generator and, for each expected generated file that is missing or whose content differs (comparing
+    ///     line-ending insensitively), overwrites it on disk with the produced output (normalized to CRLF).
+    /// </summary>
+    /// <remarks>
+    ///     Because it writes to the source tree, this is off by default. Gate it off wherever the workspace must not be
+    ///     mutated (e.g. running tests in CI) by passing <paramref name="enabled" /> a condition such as
+    ///     <c>Environment.GetEnvironmentVariable("CI") is null</c>. The assertion still runs when writes are
+    ///     suppressed, so regressions are still caught.
+    /// </remarks>
+    /// <param name="enabled">Whether to write updated expected files; defaults to <see langword="true" />.</param>
+    /// <returns>A new builder that writes updated expected files when <paramref name="enabled" /> is set.</returns>
+    public SourceGeneratorTestBuilder<TSourceGenerator, TVerifier> WithExpectedSourceUpdates(bool enabled = true)
+    {
+        var builder = Clone();
+        builder.updateExpectedSources = enabled;
+        return builder;
+    }
+
+    /// <summary>
     ///     Registers a content transform that replaces every <c>$(name)</c> token with <paramref name="value" /> in all
     ///     test case file contents (both sources and expected generated files) as they are loaded.
     /// </summary>
@@ -369,12 +391,16 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
         }
 
         var sourceFileTasks = testCase.SourceFiles.Select(file => LoadSourceFileAsync(file, testCase, token));
-        var generatedFileTasks = testCase.GeneratedFiles.Select(file => LoadGeneratedFileAsync(file, testCase, token));
-
         var sourceFiles = await Task.WhenAll(sourceFileTasks).ConfigureAwait(false);
-        var generatedFiles = await Task.WhenAll(generatedFileTasks).ConfigureAwait(false);
-
         test.TestState.Sources.AddRange(sourceFiles);
+
+        // When updating, write the generator's output over any missing/differing expected files, but assert against
+        // the pre-existing content so a write always coincides with a failure (see WithExpectedSourceUpdates).
+        var generatedFiles = this.updateExpectedSources
+            ? await UpdateAndLoadGeneratedFilesAsync(testCase, sourceFiles, token).ConfigureAwait(false)
+            : await Task.WhenAll(testCase.GeneratedFiles.Select(file => LoadGeneratedFileAsync(file, testCase, token)))
+                .ConfigureAwait(false);
+
         test.TestState.GeneratedSources.AddRange(generatedFiles);
 
         foreach (var configure in this.configurations)
@@ -395,6 +421,7 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
             disabledDiagnostics = this.disabledDiagnostics,
             generatedSources = this.generatedSources,
             includePostInitializationSources = this.includePostInitializationSources,
+            updateExpectedSources = this.updateExpectedSources,
             contentTransforms = this.contentTransforms,
             configurations = this.configurations,
             generatedFilePathResolver = this.generatedFilePathResolver,
@@ -436,6 +463,134 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
         }
 
         return contents;
+    }
+
+    private async Task<string?> TryLoadFileAsync(string? directory, string fileName, CancellationToken token)
+    {
+        var fullFileName = GetTestFilePath(directory, fileName);
+        if (!File.Exists(fullFileName))
+        {
+            return null;
+        }
+
+        return await LoadFileAsync(directory, fileName, token).ConfigureAwait(false);
+    }
+
+    private async Task<(string filename, SourceText content)[]> UpdateAndLoadGeneratedFilesAsync(
+        TestCase testCase,
+        (string filename, SourceText content)[] sourceFiles,
+        CancellationToken token
+    )
+    {
+        var produced = await GenerateSourcesAsync(sourceFiles, token).ConfigureAwait(false);
+
+        var generatedFiles = new (string filename, SourceText content)[testCase.GeneratedFiles.Length];
+        for (var i = 0; i < testCase.GeneratedFiles.Length; i++)
+        {
+            token.ThrowIfCancellationRequested();
+            var generatedFile = testCase.GeneratedFiles[i];
+
+            // The content the test will assert against: the expected file exactly as it exists now (null if it does
+            // not exist yet). Never the freshly written content — that is what keeps a mismatch a failure.
+            var original = await TryLoadFileAsync(testCase.Directory, generatedFile.SourceFileName, token)
+                .ConfigureAwait(false);
+
+            if (produced.TryGetValue(generatedFile.GeneratedFileName, out var producedText))
+            {
+                var producedContent = producedText.ToString();
+                if (original == null || !LineEndingAgnosticEquals(original, producedContent))
+                {
+                    var filePath = GetTestFilePath(testCase.Directory, generatedFile.SourceFileName);
+                    await WriteExpectedFileAsync(filePath, producedContent, token).ConfigureAwait(false);
+                }
+            }
+
+            generatedFiles[i] = (
+                ResolveGeneratedPath(generatedFile.GeneratedFileName),
+                SourceText.From(original ?? string.Empty, Encoding.UTF8)
+            );
+        }
+
+        return generatedFiles;
+    }
+
+    private async Task<Dictionary<string, SourceText>> GenerateSourcesAsync(
+        (string filename, SourceText content)[] sourceFiles,
+        CancellationToken token
+    )
+    {
+        var references = new List<MetadataReference>();
+        if (this.referenceAssemblies != null)
+        {
+            references.AddRange(
+                await this.referenceAssemblies.ResolveAsync(LanguageNames.CSharp, token).ConfigureAwait(false)
+            );
+        }
+
+        foreach (var name in this.additionalReferences)
+        {
+            var path = Path.IsPathRooted(name) ? name : Path.Combine(AppContext.BaseDirectory, name);
+            references.Add(MetadataReference.CreateFromFile(path));
+        }
+
+        var syntaxTrees = sourceFiles.Select(file =>
+            CSharpSyntaxTree.ParseText(file.content, path: file.filename, cancellationToken: token)
+        );
+
+        var compilation = CSharpCompilation.Create(
+            "ZCrew.ExpectedSourceUpdate",
+            syntaxTrees,
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        var generator = GeneratorActivator.CreateSourceGenerator<TSourceGenerator>();
+        var runResult = CSharpGeneratorDriver.Create(generator).RunGenerators(compilation, token).GetRunResult();
+
+        var produced = new Dictionary<string, SourceText>(StringComparer.Ordinal);
+        foreach (var result in runResult.Results)
+        {
+            foreach (var source in result.GeneratedSources)
+            {
+                produced[source.HintName] = source.SourceText;
+            }
+        }
+
+        return produced;
+    }
+
+    private static async Task WriteExpectedFileAsync(string filePath, string content, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        // UTF-8 without a BOM, CRLF line endings — matching the repository's checked-in generated fixtures.
+        using var writer = new StreamWriter(
+            filePath,
+            append: false,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+        );
+        await writer.WriteAsync(NormalizeToCrlf(content)).ConfigureAwait(false);
+    }
+
+    private static bool LineEndingAgnosticEquals(string left, string right)
+    {
+        return NormalizeToLf(left) == NormalizeToLf(right);
+    }
+
+    private static string NormalizeToLf(string value)
+    {
+        return value.Replace("\r\n", "\n").Replace("\r", "\n");
+    }
+
+    private static string NormalizeToCrlf(string value)
+    {
+        return NormalizeToLf(value).Replace("\n", "\r\n");
     }
 
     private string ResolveGeneratedPath(string hintName)

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestPath.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestPath.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
 
@@ -26,6 +27,25 @@ public readonly struct TestPath
     ///     This can be useful when you want to avoid starting a path without the <see cref="CurrentDirectory" />.
     /// </remarks>
     public static readonly TestPath Empty = new("");
+
+    /// <summary>
+    ///     Returns the directory of the source file that calls this method, captured at compile time via
+    ///     <see cref="CallerFilePathAttribute" />.
+    /// </summary>
+    /// <remarks>
+    ///     This resolves test fixtures relative to the source tree rather than the build output directory, so
+    ///     files loaded through the returned path (and anything written back to them) stay in the tracked source
+    ///     location. Because the path is baked in when the caller is compiled, it is valid for the local
+    ///     build-and-run loop and for CI, which builds and runs from the same checkout.
+    /// </remarks>
+    /// <param name="callerFilePath">
+    ///     Supplied automatically by the compiler; do not pass a value. The absolute path of the calling source file.
+    /// </param>
+    /// <returns>A <see cref="TestPath" /> for the directory containing the calling source file.</returns>
+    public static TestPath ForCaller([CallerFilePath] string callerFilePath = "")
+    {
+        return new TestPath(Path.GetDirectoryName(callerFilePath)!);
+    }
 
     private readonly string path;
 

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/AttributeTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/AttributeTests/AttributeTests.cs
@@ -5,7 +5,7 @@ namespace ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests.AttributeTes
 
 public class AttributeTests
 {
-    private static readonly TestPath testCases = TestPath.CurrentDirectory / "AttributeTests" / "TestCases";
+    private static readonly TestPath TestCases = TestPath.ForCaller() / "TestCases";
 
     [Theory]
     [InlineData("MultipleNamedParameters.json")]
@@ -16,7 +16,7 @@ public class AttributeTests
     public async Task EmbeddedAttribute_WithReplaceAction_ShouldGenerateCodeToReplaceServices(string testDescriptor)
     {
         // Arrange
-        var testCaseFile = testCases / testDescriptor;
+        var testCaseFile = TestCases / testDescriptor;
         var testCase = await JsonTestCase.FromJsonFileAsync(testCaseFile, TestContext.Current.CancellationToken);
 
         // Act

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/CacheTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/CacheTests.cs
@@ -9,7 +9,7 @@ namespace ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests.CacheTests;
 
 public class CacheTests
 {
-    private static readonly TestPath testCases = TestPath.CurrentDirectory / "CacheTests" / "TestCases";
+    private static readonly TestPath TestCases = TestPath.ForCaller() / "TestCases";
 
     [Theory]
     [InlineData("WithAttribute.json")]
@@ -17,9 +17,13 @@ public class CacheTests
     public async Task EmbeddedAttribute_WithMultipleBuilds_ShouldCacheIncrementalValues(string testDescriptor)
     {
         // Arrange
-        var testCaseFile = testCases / testDescriptor;
+        var testCaseFile = TestCases / testDescriptor;
         var testCase = await JsonTestCase.FromJsonFileAsync(testCaseFile, TestContext.Current.CancellationToken);
-        var test = await GeneratorTest.Baseline.BuildAsync(testCase, TestContext.Current.CancellationToken);
+        // This test only uses the loaded sources for its caching assertions and never verifies generated output, so
+        // opt out of expected-source updates to avoid a needless extra generator run and file writes.
+        var test = await GeneratorTest
+            .Baseline.WithExpectedSourceUpdates(false)
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
         var syntaxTrees = test.TestState.Sources.Select(source => CSharpSyntaxTree.ParseText(source.content)).ToArray();
 
         var sourceGenerator = new EmbeddedAttributeIncrementalGenerator();

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/EnumTests/EnumTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/EnumTests/EnumTests.cs
@@ -5,14 +5,14 @@ namespace ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests.EnumTests;
 
 public class EnumTests
 {
-    private static readonly TestPath testCases = TestPath.CurrentDirectory / "EnumTests" / "TestCases";
+    private static readonly TestPath TestCases = TestPath.ForCaller() / "TestCases";
 
     [Theory]
     [InlineData("SingleEnum.json")]
     public async Task EmbeddedAttribute_EmbeddedEnum_ShouldGenerateSourceText(string testDescriptor)
     {
         // Arrange
-        var testCaseFile = testCases / testDescriptor;
+        var testCaseFile = TestCases / testDescriptor;
         var testCase = await JsonTestCase.FromJsonFileAsync(testCaseFile, TestContext.Current.CancellationToken);
 
         // Act

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/IsTypeTests/IsTypeTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/IsTypeTests/IsTypeTests.cs
@@ -5,7 +5,7 @@ namespace ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests.IsTypeTests;
 
 public class IsTypeTests
 {
-    private static readonly TestPath testCases = TestPath.CurrentDirectory / "IsTypeTests" / "TestCases";
+    private static readonly TestPath TestCases = TestPath.ForCaller() / "TestCases";
 
     [Theory]
     [InlineData("ServiceKeyGeneric.json")]
@@ -23,7 +23,7 @@ public class IsTypeTests
     public async Task IsType_WithMarkedPartialMethod_ShouldGenerateTypeCheck(string testDescriptor)
     {
         // Arrange
-        var testCaseFile = testCases / testDescriptor;
+        var testCaseFile = TestCases / testDescriptor;
         var testCase = await JsonTestCase.FromJsonFileAsync(testCaseFile, TestContext.Current.CancellationToken);
 
         // Act

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/TestHelpers/GeneratorTest.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/TestHelpers/GeneratorTest.cs
@@ -22,7 +22,10 @@ internal static class GeneratorTest
             // Disable the warning on the source files about missing XML comments
             .WithDisabledDiagnostics("CS1591")
             // All tests will emit the post-initialization sources (e.g. 'Microsoft.CodeAnalysis.EmbeddedAttribute')
-            .WithGeneratorPostInitializationSources();
+            .WithGeneratorPostInitializationSources()
+            // Overwrite mismatched/missing expected files in place for review, but never on CI (writes only, the
+            // assertion still runs and fails regardless).
+            .WithExpectedSourceUpdates(enabled: Environment.GetEnvironmentVariable("CI") is null);
 
     /// <summary>
     ///     The shared baseline for <see cref="IsTypeIncrementalGenerator" /> tests. Mirrors <see cref="Baseline" /> but
@@ -41,5 +44,8 @@ internal static class GeneratorTest
             // Disable the warning on the source files about missing XML comments
             .WithDisabledDiagnostics("CS1591")
             // All tests will emit the post-initialization sources (e.g. the 'IsTypeAttribute' definition)
-            .WithGeneratorPostInitializationSources();
+            .WithGeneratorPostInitializationSources()
+            // Overwrite mismatched/missing expected files in place for review, but never on CI (writes only, the
+            // assertion still runs and fails regardless).
+            .WithExpectedSourceUpdates(enabled: Environment.GetEnvironmentVariable("CI") is null);
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests.csproj
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests.csproj
@@ -13,12 +13,14 @@
   <ItemGroup>
     <!-- Although these end with ".cs" these shouldn't be compiled. The file extension helps provide editor hints. -->
     <Compile Remove="**/TestCases/**/*.cs" />
-    <!-- Include the test case descriptors -->
-    <Content Include="**/TestCases/**/*.json" Exclude="bin/**/*.json" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Tests load fixtures from the source tree via TestPath.ForCaller(), so these are not copied to the output
+         directory. Keeping them out of bin avoids a duplicate copy and lets update mode write back to the tracked
+         source files. Included as None (not Content) purely for editor visibility and nesting. -->
+    <None Include="**/TestCases/**/*.json" Exclude="bin/**/*.json" />
     <!-- Include all the non-compiled testing C# files and make them dependent upon the .json test descriptor -->
-    <Content Include="**/TestCases/**/*.cs" Exclude="bin/**/*.cs" CopyToOutputDirectory="PreserveNewest">
+    <None Include="**/TestCases/**/*.cs" Exclude="bin/**/*.cs">
       <!-- Using String.Copy until this is fixed: https://github.com/dotnet/msbuild/issues/1155 -->
       <DependentUpon>$([System.String]::Concat($([System.String]::Copy(%(Filename)).Substring(0, $([System.String]::Copy(%(Filename)).IndexOf('.')))), '.json'))</DependentUpon>
-    </Content>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds in test generation to emit the source generator outputs if they aren't present or if they have changed. This will show changes as a git diff so the user can review. If they don't commit the changes then the tests will still fail in CI.

Closes #26