### PR TITLE
#25 - Add in AppendJoined

### DIFF
--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp/Text/FormattedStringBuilderExtensions.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp/Text/FormattedStringBuilderExtensions.cs
@@ -147,9 +147,9 @@ public static class FormattedStringBuilderExtensions
         /// <code>
         ///     private const string Comment =
         ///         """
-        ///         /// <summary>
+        ///         /// &lt;summary&gt;
         ///         /// Generated method for registering a component.
-        ///         /// </summary>
+        ///         /// &lt;/summary&gt;
         ///         """;
         ///     private string comment = new FormattedStringBuilder()
         ///         .Append('{')
@@ -159,14 +159,15 @@ public static class FormattedStringBuilderExtensions
         ///         .Append("public void Register() {}")
         ///         .Unindent()
         ///         .AppendLine()
-        ///         .Append('}');
+        ///         .Append('}')
+        ///         .ToString();
         /// </code>
         /// Would generate:
         /// <code>
         ///     {
-        ///         /// <summary>
+        ///         /// &lt;summary&gt;
         ///         /// Generated method for registering a component.
-        ///         /// </summary>
+        ///         /// &lt;/summary&gt;
         ///         public void Register() {}
         ///     }
         /// </code>
@@ -184,6 +185,258 @@ public static class FormattedStringBuilderExtensions
             }
 
             return builder;
+        }
+
+        /// <summary>
+        ///     Appends the <paramref name="items"/>, writing <paramref name="separator"/> between them. Each element can be
+        ///     rendered by <paramref name="appendElement"/>, which receives the builder and the item.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private readonly string[] modifiers = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"]
+        ///     private string allModifiers = new FormattedStringBuilder()
+        ///         .AppendJoined(modifiers, " ", (b, i) => b.Append(i))
+        ///         .ToString();
+        /// </code>
+        /// Would produce <c>"static extern new virtual abstract sealed override"</c>.
+        /// </example>
+        public FormattedStringBuilder AppendJoined<T>(
+            IReadOnlyList<T> items,
+            string separator,
+            Action<FormattedStringBuilder, T> appendElement
+        )
+        {
+            return builder.AppendJoined(items, 0, items.Count, separator, appendElement);
+        }
+
+        /// <summary>
+        ///     Appends the <paramref name="items"/>, writing <paramref name="separator"/> between them. Each element can be
+        ///     rendered by <paramref name="appendElement"/>, which receives the builder and the item.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private readonly string[] modifiers = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"]
+        ///     private string allModifiers = new FormattedStringBuilder()
+        ///         .AppendJoined(modifiers, 1, 5, " ", (b, i) => b.Append(i))
+        ///         .ToString();
+        /// </code>
+        /// Would produce <c>"extern new virtual abstract sealed"</c>.
+        /// </example>
+        public FormattedStringBuilder AppendJoined<T>(
+            IReadOnlyList<T> items,
+            int startIndex,
+            int count,
+            string separator,
+            Action<FormattedStringBuilder, T> appendElement
+        )
+        {
+            ValidateRange(startIndex, count, items.Count);
+            for (var i = 0; i < count; i++)
+            {
+                if (i != 0)
+                {
+                    builder.Append(separator);
+                }
+
+                appendElement(builder, items[startIndex + i]);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        ///     Appends the <paramref name="items"/>, writing <paramref name="separator"/> between them. Each element can be
+        ///     rendered by <paramref name="appendElement"/>, which receives the builder and the item.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private readonly string[] modifiers = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"]
+        ///     private string allModifiers = new FormattedStringBuilder()
+        ///         .AppendJoined(modifiers, ' ', (b, i) => b.Append(i))
+        ///         .ToString();
+        /// </code>
+        /// Would produce <c>"static extern new virtual abstract sealed override"</c>.
+        /// </example>
+        public FormattedStringBuilder AppendJoined<T>(
+            IReadOnlyList<T> items,
+            char separator,
+            Action<FormattedStringBuilder, T> appendElement
+        )
+        {
+            return builder.AppendJoined(items, 0, items.Count, separator, appendElement);
+        }
+
+        /// <summary>
+        ///     Appends the <paramref name="items"/>, writing <paramref name="separator"/> between them. Each element can be
+        ///     rendered by <paramref name="appendElement"/>, which receives the builder and the item.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private readonly string[] modifiers = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"]
+        ///     private string allModifiers = new FormattedStringBuilder()
+        ///         .AppendJoined(modifiers, 1, 5, ' ', (b, i) => b.Append(i))
+        ///         .ToString();
+        /// </code>
+        /// Would produce <c>"extern new virtual abstract sealed"</c>.
+        /// </example>
+        public FormattedStringBuilder AppendJoined<T>(
+            IReadOnlyList<T> items,
+            int startIndex,
+            int count,
+            char separator,
+            Action<FormattedStringBuilder, T> appendElement
+        )
+        {
+            ValidateRange(startIndex, count, items.Count);
+            for (var i = 0; i < count; i++)
+            {
+                if (i != 0)
+                {
+                    builder.Append(separator);
+                }
+
+                appendElement(builder, items[startIndex + i]);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        ///     Appends the <paramref name="items"/>, writing <paramref name="separator"/> between them. Each element can be
+        ///     rendered by <paramref name="appendElement"/>, which receives the builder and the item.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private readonly string[] modifiers = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"]
+        ///     private string allModifiers = new FormattedStringBuilder()
+        ///         .AppendJoined(modifiers, " ", (b, i) => b.Append(i))
+        ///         .ToString();
+        /// </code>
+        /// Would produce <c>"static extern new virtual abstract sealed override"</c>.
+        /// </example>
+        public FormattedStringBuilder AppendJoined<T>(
+            ReadOnlySpan<T> items,
+            string separator,
+            Action<FormattedStringBuilder, T> appendElement
+        )
+        {
+            return builder.AppendJoined(items, 0, items.Length, separator, appendElement);
+        }
+
+        /// <summary>
+        ///     Appends the <paramref name="items"/>, writing <paramref name="separator"/> between them. Each element can be
+        ///     rendered by <paramref name="appendElement"/>, which receives the builder and the item.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private readonly string[] modifiers = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"]
+        ///     private string allModifiers = new FormattedStringBuilder()
+        ///         .AppendJoined(modifiers, 1, 5, " ", (b, i) => b.Append(i))
+        ///         .ToString();
+        /// </code>
+        /// Would produce <c>"extern new virtual abstract sealed"</c>.
+        /// </example>
+        public FormattedStringBuilder AppendJoined<T>(
+            ReadOnlySpan<T> items,
+            int startIndex,
+            int count,
+            string separator,
+            Action<FormattedStringBuilder, T> appendElement
+        )
+        {
+            ValidateRange(startIndex, count, items.Length);
+            for (var i = 0; i < count; i++)
+            {
+                if (i != 0)
+                {
+                    builder.Append(separator);
+                }
+
+                appendElement(builder, items[startIndex + i]);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        ///     Appends the <paramref name="items"/>, writing <paramref name="separator"/> between them. Each element can be
+        ///     rendered by <paramref name="appendElement"/>, which receives the builder and the item.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private readonly string[] modifiers = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"]
+        ///     private string allModifiers = new FormattedStringBuilder()
+        ///         .AppendJoined(modifiers, ' ', (b, i) => b.Append(i))
+        ///         .ToString();
+        /// </code>
+        /// Would produce <c>"static extern new virtual abstract sealed override"</c>.
+        /// </example>
+        public FormattedStringBuilder AppendJoined<T>(
+            ReadOnlySpan<T> items,
+            char separator,
+            Action<FormattedStringBuilder, T> appendElement
+        )
+        {
+            return builder.AppendJoined(items, 0, items.Length, separator, appendElement);
+        }
+
+        /// <summary>
+        ///     Appends the <paramref name="items"/>, writing <paramref name="separator"/> between them. Each element can be
+        ///     rendered by <paramref name="appendElement"/>, which receives the builder and the item.
+        /// </summary>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <example>
+        /// <code>
+        ///     private readonly string[] modifiers = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"]
+        ///     private string allModifiers = new FormattedStringBuilder()
+        ///         .AppendJoined(modifiers, 1, 5, ' ', (b, i) => b.Append(i))
+        ///         .ToString();
+        /// </code>
+        /// Would produce <c>"extern new virtual abstract sealed"</c>.
+        /// </example>
+        public FormattedStringBuilder AppendJoined<T>(
+            ReadOnlySpan<T> items,
+            int startIndex,
+            int count,
+            char separator,
+            Action<FormattedStringBuilder, T> appendElement
+        )
+        {
+            ValidateRange(startIndex, count, items.Length);
+            for (var i = 0; i < count; i++)
+            {
+                if (i != 0)
+                {
+                    builder.Append(separator);
+                }
+
+                appendElement(builder, items[startIndex + i]);
+            }
+
+            return builder;
+        }
+    }
+
+    private static void ValidateRange(int startIndex, int count, int length)
+    {
+        if (startIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startIndex), startIndex, "Start must be non-negative");
+        }
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), count, "Count must be non-negative");
+        }
+        if (length < count + startIndex)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), count + startIndex, $"There are only {length} items");
         }
     }
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests/Text/FormattedStringBuilderExtensionsTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.UnitTests/Text/FormattedStringBuilderExtensionsTests.cs
@@ -189,4 +189,276 @@ public class FormattedStringBuilderExtensionsTests
             """;
         Assert.Equal(expectedString, formattedStringBuilder.ToString());
     }
+
+    [Fact]
+    public void AppendJoined_WithListAndStringSeparator_ShouldJoinAllElements()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, ", ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("static, extern, new", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithListAndCharSeparator_ShouldJoinAllElements()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, ' ', (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("static extern new", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithSpanAndStringSeparator_ShouldJoinAllElements()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        ReadOnlySpan<string> items = ["static", "extern", "new"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, ", ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("static, extern, new", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithSpanAndCharSeparator_ShouldJoinAllElements()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        ReadOnlySpan<string> items = ["static", "extern", "new"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, ' ', (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("static extern new", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithListRangeAndStringSeparator_ShouldJoinOnlySubrange()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, 1, 5, " ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("extern new virtual abstract sealed", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithListRangeAndCharSeparator_ShouldJoinOnlySubrange()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, 1, 5, ' ', (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("extern new virtual abstract sealed", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithSpanRangeAndStringSeparator_ShouldJoinOnlySubrange()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        ReadOnlySpan<string> items = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, 1, 5, " ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("extern new virtual abstract sealed", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithSpanRangeAndCharSeparator_ShouldJoinOnlySubrange()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        ReadOnlySpan<string> items = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, 1, 5, ' ', (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("extern new virtual abstract sealed", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithEmptyList_ShouldAppendNothing()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = [];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, ", ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Empty(formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithSingleElement_ShouldNotAppendSeparator()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, ", ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("static", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithZeroCount_ShouldAppendNothing()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, 1, 0, ", ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Empty(formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithRangeEndingAtLastElement_ShouldJoinToEnd()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new", "virtual", "abstract", "sealed", "override"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, 5, 2, " ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Equal("sealed override", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WithCustomAppendElement_ShouldRenderEachElementViaCallback()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new"];
+
+        // Act
+        formattedStringBuilder.AppendJoined(items, " ", (b, m) => b.Append(m.ToUpperInvariant()));
+
+        // Assert
+        Assert.Equal("STATIC EXTERN NEW", formattedStringBuilder.ToString());
+    }
+
+    [Fact]
+    public void AppendJoined_WhenCalled_ShouldReturnSameBuilder()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern"];
+
+        // Act
+        var result = formattedStringBuilder.AppendJoined(items, " ", (b, m) => b.Append(m));
+
+        // Assert
+        Assert.Same(formattedStringBuilder, result);
+    }
+
+    [Fact]
+    public void AppendJoined_WithNegativeStartIndex_ShouldThrowForStartIndex()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new"];
+
+        // Act
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            formattedStringBuilder.AppendJoined(items, -1, 1, " ", (b, m) => b.Append(m))
+        );
+
+        // Assert
+        Assert.Equal("startIndex", exception.ParamName);
+    }
+
+    [Fact]
+    public void AppendJoined_WithNegativeCount_ShouldThrowForCount()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new"];
+
+        // Act
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            formattedStringBuilder.AppendJoined(items, 0, -1, " ", (b, m) => b.Append(m))
+        );
+
+        // Assert
+        Assert.Equal("count", exception.ParamName);
+    }
+
+    [Fact]
+    public void AppendJoined_WithRangeExceedingCount_ShouldThrowForCount()
+    {
+        // Arrange
+        var formattedStringBuilder = new FormattedStringBuilder();
+        List<string> items = ["static", "extern", "new"];
+
+        // Act
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            formattedStringBuilder.AppendJoined(items, 2, 5, " ", (b, m) => b.Append(m))
+        );
+
+        // Assert
+        Assert.Equal("count", exception.ParamName);
+    }
+
+    [Fact]
+    public void AppendJoined_WithSpanAndNegativeStartIndex_ShouldThrowForStartIndex()
+    {
+        // Act
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            ReadOnlySpan<string> items = ["static", "extern", "new"];
+            new FormattedStringBuilder().AppendJoined(items, -1, 1, " ", (b, m) => b.Append(m));
+        });
+
+        // Assert
+        Assert.Equal("startIndex", exception.ParamName);
+    }
+
+    [Fact]
+    public void AppendJoined_WithSpanAndRangeExceedingLength_ShouldThrowForCount()
+    {
+        // Act
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            ReadOnlySpan<string> items = ["static", "extern", "new"];
+            new FormattedStringBuilder().AppendJoined(items, 2, 5, " ", (b, m) => b.Append(m));
+        });
+
+        // Assert
+        Assert.Equal("count", exception.ParamName);
+    }
 }


### PR DESCRIPTION
Adds `AppendJoined` to the `FormattedStringBuilder` to provide functionality similar to `string.Join`. This supports `IReadOnlyList` and `ReadOnlySpan` for now with `string` and `char` separators.

Closes #25