### PR TITLE
#29 - Add in TestName property and additional enhancements

### DIFF
--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/ITestCase.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/ITestCase.cs
@@ -1,0 +1,40 @@
+namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
+
+/// <summary>
+///     Describes a single source generator test: the source files to compile and the generated files to verify
+///     against.
+/// </summary>
+public interface ITestCase
+{
+    /// <summary>
+    ///     The name of the test. Typically, this is the name of the test metadata file without an extension.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    ///     An optional human-readable description of the test case. Not used during execution.
+    /// </summary>
+    string? Description { get; }
+
+    /// <summary>
+    ///     The source files compiled as input to the generator.
+    /// </summary>
+    IReadOnlyList<TestSourceFile> SourceFiles { get; }
+
+    /// <summary>
+    ///     The generated files the test expects the generator to produce.
+    /// </summary>
+    IReadOnlyList<TestGeneratedFile> GeneratedFiles { get; }
+
+    /// <summary>
+    ///     The directory that <see cref="SourceFiles" /> and <see cref="TestGeneratedFile.SourceFileName" /> are
+    ///     resolved relative to. Typically set to the directory of the descriptor that produced this test case (for
+    ///     example by <see cref="JsonTestCase.FromJsonFile" />).
+    /// </summary>
+    string? Directory { get; }
+
+    /// <summary>
+    ///     All other properties from the test file that didn't match an existing property.
+    /// </summary>
+    IReadOnlyDictionary<string, object> Properties { get; }
+}

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/JsonTestCase.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/JsonTestCase.cs
@@ -1,12 +1,38 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
 
 /// <summary>
 ///     Loads a <see cref="TestCase" /> from a JSON descriptor file.
 /// </summary>
-public class JsonTestCase : TestCase
+public class JsonTestCase : ITestCase
 {
+    /// <inheritdoc />
+    public string Name { get; private set; } = null!;
+
+    /// <inheritdoc />
+    public string? Directory { get; private set; }
+
+    /// <inheritdoc />
+    [JsonInclude]
+    public string? Description { get; private set; }
+
+    /// <inheritdoc />
+    [JsonInclude]
+    public IReadOnlyList<TestSourceFile> SourceFiles { get; private set; } = [];
+
+    /// <inheritdoc />
+    [JsonInclude]
+    public IReadOnlyList<TestGeneratedFile> GeneratedFiles { get; private set; } = [];
+
+    /// <inheritdoc cref="ITestCase.Properties"/>
+    [JsonInclude, JsonExtensionData]
+    public Dictionary<string, object> Properties { get; private set; } = [];
+
+    /// <inheritdoc cref="ITestCase.Properties"/>
+    IReadOnlyDictionary<string, object> ITestCase.Properties => Properties;
+
     /// <summary>
     ///     Deserializes a <see cref="TestCase" /> from the JSON descriptor at <paramref name="testFilePath" />.
     /// </summary>
@@ -17,15 +43,16 @@ public class JsonTestCase : TestCase
     /// <exception cref="FileNotFoundException">Thrown when <paramref name="testFilePath" /> does not exist.</exception>
     /// <exception cref="IOException">Thrown when the descriptor cannot be parsed into a <see cref="TestCase" />.</exception>
     /// <exception cref="JsonException">Thrown when the descriptor is not valid JSON.</exception>
-    public static TestCase FromJsonFile(string testFilePath)
+    public static JsonTestCase FromJsonFile(string testFilePath)
     {
         using var fileStream = File.OpenRead(testFilePath);
-        var testCase = JsonSerializer.Deserialize<TestCase>(fileStream);
+        var testCase = JsonSerializer.Deserialize<JsonTestCase>(fileStream);
         if (testCase == null)
         {
             throw new IOException($"Failed to parse test case from file: {testFilePath}");
         }
 
+        testCase.Name = Path.GetFileNameWithoutExtension(testFilePath);
         testCase.Directory = Path.GetDirectoryName(testFilePath);
         return testCase;
     }
@@ -43,15 +70,16 @@ public class JsonTestCase : TestCase
     /// <exception cref="IOException">Thrown when the descriptor cannot be parsed into a <see cref="TestCase" />.</exception>
     /// <exception cref="JsonException">Thrown when the descriptor is not valid JSON.</exception>
     /// <exception cref="OperationCanceledException">Thrown when <paramref name="token" /> is canceled.</exception>
-    public static async Task<TestCase> FromJsonFileAsync(string testFilePath, CancellationToken token = default)
+    public static async Task<JsonTestCase> FromJsonFileAsync(string testFilePath, CancellationToken token = default)
     {
         using var fileStream = File.OpenRead(testFilePath);
-        var testCase = await JsonSerializer.DeserializeAsync<TestCase>(fileStream, cancellationToken: token);
+        var testCase = await JsonSerializer.DeserializeAsync<JsonTestCase>(fileStream, cancellationToken: token);
         if (testCase == null)
         {
             throw new IOException($"Failed to parse test case from file: {testFilePath}");
         }
 
+        testCase.Name = Path.GetFileNameWithoutExtension(testFilePath);
         testCase.Directory = Path.GetDirectoryName(testFilePath);
         return testCase;
     }

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/SourceGeneratorTestBuilder.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/SourceGeneratorTestBuilder.cs
@@ -41,7 +41,7 @@ public static class SourceGeneratorTestBuilder<TSourceGenerator>
 
 /// <summary>
 ///     Builds <see cref="CSharpSourceGeneratorTest{TSourceGenerator, TVerifier}" /> instances from a
-///     <see cref="TestCase" />.
+///     <see cref="ITestCase" />.
 /// </summary>
 /// <remarks>
 ///     The builder is immutable: every <c>With*</c> method returns a new builder and leaves the original unchanged.
@@ -66,7 +66,7 @@ public static class SourceGeneratorTestBuilder<TSourceGenerator>
 ///     [Fact]
 ///     public async Task Generates_Expected_Sources()
 ///     {
-///         var testCase = await JsonTestCase.FromJsonFileAsync("TestCases/MyCase.json");
+///         var testCase = await JsonTestCase.FromJsonFileAsync("ITestCases/MyCase.json");
 ///         // The shared Baseline is never mutated; BuildAsync produces a fresh test.
 ///         var test = await Baseline.BuildAsync(testCase);
 ///         await test.RunAsync();
@@ -81,13 +81,14 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
     private ImmutableList<string> additionalReferences = ImmutableList<string>.Empty;
     private CompilerDiagnostics? compilerDiagnostics;
     private ImmutableList<string> disabledDiagnostics = ImmutableList<string>.Empty;
+
     private ImmutableList<(string HintName, SourceText Content)> generatedSources = ImmutableList<(
         string HintName,
         SourceText Content
     )>.Empty;
+    private ImmutableDictionary<string, object?> properties = ImmutableDictionary<string, object?>.Empty;
     private bool includePostInitializationSources;
     private bool updateExpectedSources;
-    private ImmutableList<Func<string, string>> contentTransforms = ImmutableList<Func<string, string>>.Empty;
     private ImmutableList<Action<CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>>> configurations =
         ImmutableList<Action<CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>>>.Empty;
     private Func<string, string>? generatedFilePathResolver;
@@ -282,21 +283,10 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
     ///     builder.WithVariable("Namespace", "MyApp.Generated");
     ///     </code>
     /// </example>
-    public SourceGeneratorTestBuilder<TSourceGenerator, TVerifier> WithVariable(string name, string value)
-    {
-        return WithContentTransform(content => content.Replace($"$({name})", value));
-    }
-
-    /// <summary>
-    ///     Adds a transform applied to all test case file contents (sources and expected generated files) as they are
-    ///     loaded. Transforms run in registration order.
-    /// </summary>
-    /// <param name="transform">A function that maps the raw file contents to the contents used by the test.</param>
-    /// <returns>A new builder that applies <paramref name="transform" /> when loading file contents.</returns>
-    public SourceGeneratorTestBuilder<TSourceGenerator, TVerifier> WithContentTransform(Func<string, string> transform)
+    public SourceGeneratorTestBuilder<TSourceGenerator, TVerifier> WithVariable(string name, object? value)
     {
         var builder = Clone();
-        builder.contentTransforms = this.contentTransforms.Add(transform);
+        builder.properties = builder.properties.Add(name, value);
         return builder;
     }
 
@@ -337,7 +327,7 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
     /// </summary>
     /// <param name="testCase">
     ///     The test case describing the source files to compile and the generated files to verify. File names are
-    ///     resolved relative to <see cref="TestCase.Directory" />.
+    ///     resolved relative to <see cref="ITestCase.Directory" />.
     /// </param>
     /// <param name="token">A token to cancel the asynchronous file loading.</param>
     /// <returns>A configured test that has not yet been run.</returns>
@@ -351,7 +341,7 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
     ///     an <see cref="IIncrementalGenerator" /> nor an <see cref="ISourceGenerator" />.
     /// </exception>
     public async Task<CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>> BuildAsync(
-        TestCase testCase,
+        ITestCase testCase,
         CancellationToken token = default
     )
     {
@@ -422,7 +412,6 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
             generatedSources = this.generatedSources,
             includePostInitializationSources = this.includePostInitializationSources,
             updateExpectedSources = this.updateExpectedSources,
-            contentTransforms = this.contentTransforms,
             configurations = this.configurations,
             generatedFilePathResolver = this.generatedFilePathResolver,
         };
@@ -430,83 +419,80 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
 
     private async Task<(string filename, SourceText content)> LoadSourceFileAsync(
         TestSourceFile testSourceFile,
-        TestCase testCase,
+        ITestCase testCase,
         CancellationToken token
     )
     {
-        var contents = await LoadFileAsync(testCase.Directory, testSourceFile.SourceFileName, token)
-            .ConfigureAwait(false);
-        return (testSourceFile.SourceFileName, SourceText.From(contents, Encoding.UTF8));
+        var fileName = ExpandVariables(testCase, testSourceFile.SourceFileName);
+        var contents = await LoadFileAsync(testCase, fileName, token).ConfigureAwait(false);
+        return (fileName, SourceText.From(contents, Encoding.UTF8));
     }
 
     private async Task<(string filename, SourceText content)> LoadGeneratedFileAsync(
         TestGeneratedFile testGeneratedFile,
-        TestCase testCase,
+        ITestCase testCase,
         CancellationToken token
     )
     {
-        var contents = await LoadFileAsync(testCase.Directory, testGeneratedFile.SourceFileName, token)
-            .ConfigureAwait(false);
-        return (ResolveGeneratedPath(testGeneratedFile.GeneratedFileName), SourceText.From(contents, Encoding.UTF8));
+        var sourceFileName = ExpandVariables(testCase, testGeneratedFile.SourceFileName);
+        var contents = await LoadFileAsync(testCase, sourceFileName, token).ConfigureAwait(false);
+        var generatedFileName = ExpandVariables(testCase, testGeneratedFile.GeneratedFileName);
+        return (ResolveGeneratedPath(generatedFileName), SourceText.From(contents, Encoding.UTF8));
     }
 
-    private async Task<string> LoadFileAsync(string? directory, string fileName, CancellationToken token)
+    private async Task<string> LoadFileAsync(ITestCase testCase, string fileName, CancellationToken token)
     {
         token.ThrowIfCancellationRequested();
-        var fullFileName = GetTestFilePath(directory, fileName);
+        var fullFileName = GetTestFilePath(testCase.Directory, fileName);
         using var reader = new StreamReader(fullFileName, Encoding.UTF8);
         var contents = await reader.ReadToEndAsync().ConfigureAwait(false);
 
-        foreach (var transform in this.contentTransforms)
-        {
-            contents = transform(contents);
-        }
-
-        return contents;
+        return ExpandVariables(testCase, contents);
     }
 
-    private async Task<string?> TryLoadFileAsync(string? directory, string fileName, CancellationToken token)
+    private async Task<string?> TryLoadFileAsync(ITestCase testCase, string fileName, CancellationToken token)
     {
-        var fullFileName = GetTestFilePath(directory, fileName);
+        var fullFileName = GetTestFilePath(testCase.Directory, fileName);
         if (!File.Exists(fullFileName))
         {
             return null;
         }
 
-        return await LoadFileAsync(directory, fileName, token).ConfigureAwait(false);
+        return await LoadFileAsync(testCase, fileName, token).ConfigureAwait(false);
     }
 
     private async Task<(string filename, SourceText content)[]> UpdateAndLoadGeneratedFilesAsync(
-        TestCase testCase,
+        ITestCase testCase,
         (string filename, SourceText content)[] sourceFiles,
         CancellationToken token
     )
     {
         var produced = await GenerateSourcesAsync(sourceFiles, token).ConfigureAwait(false);
 
-        var generatedFiles = new (string filename, SourceText content)[testCase.GeneratedFiles.Length];
-        for (var i = 0; i < testCase.GeneratedFiles.Length; i++)
+        var generatedFiles = new (string filename, SourceText content)[testCase.GeneratedFiles.Count];
+        for (var i = 0; i < testCase.GeneratedFiles.Count; i++)
         {
             token.ThrowIfCancellationRequested();
             var generatedFile = testCase.GeneratedFiles[i];
+            var sourceFileName = ExpandVariables(testCase, generatedFile.SourceFileName);
+            var generatedFileName = ExpandVariables(testCase, generatedFile.GeneratedFileName);
 
             // The content the test will assert against: the expected file exactly as it exists now (null if it does
             // not exist yet). Never the freshly written content — that is what keeps a mismatch a failure.
-            var original = await TryLoadFileAsync(testCase.Directory, generatedFile.SourceFileName, token)
-                .ConfigureAwait(false);
+            var original = await TryLoadFileAsync(testCase, sourceFileName, token).ConfigureAwait(false);
 
-            if (produced.TryGetValue(generatedFile.GeneratedFileName, out var producedText))
+            if (produced.TryGetValue(generatedFileName, out var producedText))
             {
                 var producedContent = producedText.ToString();
                 if (original == null || !LineEndingAgnosticEquals(original, producedContent))
                 {
-                    var filePath = GetTestFilePath(testCase.Directory, generatedFile.SourceFileName);
+                    var filePath = GetTestFilePath(testCase.Directory, sourceFileName);
                     await WriteExpectedFileAsync(filePath, producedContent, token).ConfigureAwait(false);
                 }
             }
 
             generatedFiles[i] = (
-                ResolveGeneratedPath(generatedFile.GeneratedFileName),
+                ResolveGeneratedPath(generatedFileName),
                 SourceText.From(original ?? string.Empty, Encoding.UTF8)
             );
         }
@@ -604,6 +590,23 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
             / typeof(TSourceGenerator).Assembly.GetName().Name
             / typeof(TSourceGenerator).FullName
             / hintName;
+    }
+
+    private string ExpandVariables(ITestCase testCase, string text)
+    {
+        // Avoid allocating a new copy just to add this special case
+        text = text.Replace("$(TestName)", testCase.Name);
+
+        foreach (var property in this.properties)
+        {
+            text = text.Replace($"$({property.Key})", property.Value?.ToString() ?? string.Empty);
+        }
+        foreach (var property in testCase.Properties)
+        {
+            text = text.Replace($"$({property.Key})", property.Value?.ToString() ?? string.Empty);
+        }
+
+        return text;
     }
 
     private static string GetTestFilePath(string? directory, string fileName)

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestCase.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestCase.cs
@@ -4,27 +4,53 @@ namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
 ///     Describes a single source generator test: the source files to compile and the generated files to verify
 ///     against.
 /// </summary>
-public class TestCase
+public class TestCase : ITestCase
 {
+    /// <summary>
+    ///     Initializes a new empty <see cref="TestCase"/>.
+    /// </summary>
+    public TestCase()
+    {
+        Name = string.Empty;
+    }
+
+    /// <summary>
+    ///     Initializes a new empty <see cref="TestCase"/> named <see cref="Name"/>.
+    /// </summary>
+    /// <param name="name">The test name.</param>
+    public TestCase(string name)
+    {
+        Name = name;
+    }
+
+    /// <summary>
+    ///     The name of the test. Typically, this is the name of the test metadata file without an extension.
+    /// </summary>
+    public string Name { get; set; }
+
     /// <summary>
     ///     An optional human-readable description of the test case. Not used during execution.
     /// </summary>
     public string? Description { get; set; }
 
-    /// <summary>
-    ///     The source files compiled as input to the generator.
-    /// </summary>
-    public TestSourceFile[] SourceFiles { get; set; } = [];
+    /// <inheritdoc cref="ITestCase.SourceFiles"/>
+    public List<TestSourceFile> SourceFiles { get; set; } = [];
 
-    /// <summary>
-    ///     The generated files the test expects the generator to produce.
-    /// </summary>
-    public TestGeneratedFile[] GeneratedFiles { get; set; } = [];
+    /// <inheritdoc cref="ITestCase.SourceFiles"/>
+    IReadOnlyList<TestSourceFile> ITestCase.SourceFiles => SourceFiles;
 
-    /// <summary>
-    ///     The directory that <see cref="SourceFiles" /> and <see cref="TestGeneratedFile.SourceFileName" /> are
-    ///     resolved relative to. Typically set to the directory of the descriptor that produced this test case (for
-    ///     example by <see cref="JsonTestCase.FromJsonFile" />).
-    /// </summary>
+    /// <inheritdoc cref="ITestCase.GeneratedFiles"/>
+    public List<TestGeneratedFile> GeneratedFiles { get; set; } = [];
+
+    /// <inheritdoc cref="ITestCase.GeneratedFiles"/>
+    IReadOnlyList<TestGeneratedFile> ITestCase.GeneratedFiles => GeneratedFiles;
+
+    /// <inheritdoc/>
     public string? Directory { get; set; }
+
+    /// <inheritdoc cref="ITestCase.Properties"/>
+    public Dictionary<string, object> Properties { get; set; } = [];
+
+    /// <inheritdoc cref="ITestCase.Properties"/>
+    IReadOnlyDictionary<string, object> ITestCase.Properties => Properties;
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/SingleEnum.json
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/CacheTests/TestCases/SingleEnum.json
@@ -1,12 +1,12 @@
 {
     "SourceFiles": [
         {
-            "SourceFileName": "SingleEnum.Enum.cs"
+            "SourceFileName": "$(TestName).Enum.cs"
         }
     ],
     "GeneratedFiles": [
         {
-            "SourceFileName": "SingleEnum.SourceText.g.cs",
+            "SourceFileName": "$(TestName).SourceText.g.cs",
             "GeneratedFileName": "CacheTests.TestEnumSourceText.g.cs"
         }
     ]

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests/SourceGeneratorTestBuilderFacadeTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests/SourceGeneratorTestBuilderFacadeTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
 using ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests.TestDoubles;
 
 namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests;

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests/SourceGeneratorTestBuilderTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests/SourceGeneratorTestBuilderTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
-using ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
 using ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests.TestDoubles;
 
 namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests;
@@ -11,8 +10,6 @@ public class SourceGeneratorTestBuilderTests
     {
         return Path.Combine(typeof(TGenerator).Assembly.GetName().Name!, typeof(TGenerator).FullName!, hintName);
     }
-
-    // --- Configuration is applied to the built test ---
 
     [Fact]
     public async Task WithReferenceAssemblies_ShouldSetReferenceAssemblies()
@@ -85,8 +82,6 @@ public class SourceGeneratorTestBuilderTests
         Assert.Contains("CS9999", test.DisabledDiagnostics);
     }
 
-    // --- Generated source path resolution ---
-
     [Fact]
     public async Task WithGeneratedSource_ShouldResolveToDefaultGeneratedPath()
     {
@@ -135,8 +130,6 @@ public class SourceGeneratorTestBuilderTests
         Assert.Contains(PostInitializationGenerator.Content, content.ToString());
     }
 
-    // --- Immutability (fork-on-write) ---
-
     [Fact]
     public async Task WithDisabledDiagnostic_ShouldNotMutateOriginalBuilder()
     {
@@ -153,8 +146,6 @@ public class SourceGeneratorTestBuilderTests
         Assert.Equal(["CS0001"], baseTest.DisabledDiagnostics);
         Assert.Equal(["CS0001", "CS0002"], forkedTest.DisabledDiagnostics);
     }
-
-    // --- Content transforms applied when loading files ---
 
     [Fact]
     public async Task WithVariable_ShouldReplaceTokenInSourceContent()
@@ -181,12 +172,12 @@ public class SourceGeneratorTestBuilderTests
     }
 
     [Fact]
-    public async Task WithContentTransform_ShouldApplyTransformsInRegistrationOrder()
+    public async Task BuildAsync_ShouldExpandTestNameTokenInSourceContent()
     {
         // Arrange
         using var temp = new TempDirectory();
-        temp.WriteFile("Source.cs", "a");
-        var testCase = new TestCase
+        temp.WriteFile("Source.cs", "class $(TestName) { }");
+        var testCase = new TestCase("MyTest")
         {
             Directory = temp.DirectoryPath,
             SourceFiles = [new TestSourceFile { SourceFileName = "Source.cs" }],
@@ -195,16 +186,112 @@ public class SourceGeneratorTestBuilderTests
         // Act
         var test = await SourceGeneratorTestBuilder<EmptyGenerator>
             .Create()
-            .WithContentTransform(content => content.Replace("a", "b"))
-            .WithContentTransform(content => content.Replace("b", "c"))
             .BuildAsync(testCase, TestContext.Current.CancellationToken);
 
         // Assert
-        var (_, transformed) = Assert.Single(test.TestState.Sources);
-        Assert.Equal("c", transformed.ToString());
+        var (_, content) = Assert.Single(test.TestState.Sources);
+        Assert.Equal("class MyTest { }", content.ToString());
     }
 
-    // --- BuildAsync file loading and errors ---
+    [Fact]
+    public async Task BuildAsync_ShouldExpandTestNameTokenInSourceFileName()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        temp.WriteFile("MyTest.Source.cs", "// content");
+        var testCase = new TestCase("MyTest")
+        {
+            Directory = temp.DirectoryPath,
+            SourceFiles = [new TestSourceFile { SourceFileName = "$(TestName).Source.cs" }],
+        };
+
+        // Act
+        var test = await SourceGeneratorTestBuilder<EmptyGenerator>
+            .Create()
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert
+        var (filename, content) = Assert.Single(test.TestState.Sources);
+        Assert.Equal("MyTest.Source.cs", filename);
+        Assert.Equal("// content", content.ToString());
+    }
+
+    [Fact]
+    public async Task BuildAsync_ShouldExpandTestNameTokenInGeneratedFileNames()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        temp.WriteFile("MyTest.Expected.g.cs", "// expected");
+        var testCase = new TestCase("MyTest")
+        {
+            Directory = temp.DirectoryPath,
+            GeneratedFiles =
+            [
+                new TestGeneratedFile
+                {
+                    SourceFileName = "$(TestName).Expected.g.cs",
+                    GeneratedFileName = "$(TestName).g.cs",
+                },
+            ],
+        };
+
+        // Act
+        var test = await SourceGeneratorTestBuilder<EmptyGenerator>
+            .Create()
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert
+        var (filename, content) = Assert.Single(test.TestState.GeneratedSources);
+        Assert.Equal(ExpectedGeneratedPath<EmptyGenerator>("MyTest.g.cs"), filename);
+        Assert.Equal("// expected", content.ToString());
+    }
+
+    [Fact]
+    public async Task BuildAsync_ShouldExpandTestCasePropertyTokenInSourceContent()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        temp.WriteFile("Source.cs", "class $(Name) { }");
+        var testCase = new TestCase
+        {
+            Directory = temp.DirectoryPath,
+            SourceFiles = [new TestSourceFile { SourceFileName = "Source.cs" }],
+            Properties = new Dictionary<string, object> { ["Name"] = "Foo" },
+        };
+
+        // Act
+        var test = await SourceGeneratorTestBuilder<EmptyGenerator>
+            .Create()
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert
+        var (_, content) = Assert.Single(test.TestState.Sources);
+        Assert.Equal("class Foo { }", content.ToString());
+    }
+
+    [Fact]
+    public async Task BuildAsync_WhenBuilderAndTestCaseDefineSameVariable_ShouldPreferBuilderVariable()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        temp.WriteFile("Source.cs", "class $(Name) { }");
+        var testCase = new TestCase
+        {
+            Directory = temp.DirectoryPath,
+            SourceFiles = [new TestSourceFile { SourceFileName = "Source.cs" }],
+            Properties = new Dictionary<string, object> { ["Name"] = "FromTestCase" },
+        };
+
+        // Act
+        var test = await SourceGeneratorTestBuilder<EmptyGenerator>
+            .Create()
+            .WithVariable("Name", "FromBuilder")
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert
+        var (_, content) = Assert.Single(test.TestState.Sources);
+        Assert.Equal("class FromBuilder { }", content.ToString());
+    }
 
     [Fact]
     public async Task BuildAsync_ShouldLoadGeneratedFileAtResolvedPath()


### PR DESCRIPTION
Add in the `$(TestName)` property and remove the heavy content modifiers in-place of just property-replacement. To consolidate this, properties can be set on the tests which then will replace the content of the source and generated files.

Closes #29