### PR TITLE
#31 - Add expected diagnostics

### DIFF
--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/ITestCase.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/ITestCase.cs
@@ -27,6 +27,13 @@ public interface ITestCase
     IReadOnlyList<TestGeneratedFile> GeneratedFiles { get; }
 
     /// <summary>
+    ///     The diagnostics the test expects the compilation or generator to report with no location
+    ///     (<see cref="Microsoft.CodeAnalysis.Location.None" />). Diagnostics tied to a specific file are declared on
+    ///     that <see cref="TestSourceFile" /> or <see cref="TestGeneratedFile" /> instead.
+    /// </summary>
+    IReadOnlyList<TestExpectedDiagnostic> ExpectedDiagnostics { get; }
+
+    /// <summary>
     ///     The directory that <see cref="SourceFiles" /> and <see cref="TestGeneratedFile.SourceFileName" /> are
     ///     resolved relative to. Typically set to the directory of the descriptor that produced this test case (for
     ///     example by <see cref="JsonTestCase.FromJsonFile" />).

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/JsonTestCase.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/JsonTestCase.cs
@@ -26,6 +26,10 @@ public class JsonTestCase : ITestCase
     [JsonInclude]
     public IReadOnlyList<TestGeneratedFile> GeneratedFiles { get; private set; } = [];
 
+    /// <inheritdoc />
+    [JsonInclude]
+    public IReadOnlyList<TestExpectedDiagnostic> ExpectedDiagnostics { get; private set; } = [];
+
     /// <inheritdoc cref="ITestCase.Properties"/>
     [JsonInclude, JsonExtensionData]
     public Dictionary<string, object> Properties { get; private set; } = [];

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/README.md
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/README.md
@@ -18,7 +18,7 @@ A test case is three kinds of file in a `TestCases/` folder next to your test cl
 
 - **Input sources** (e.g. `MyCase.Attribute.cs`) compiled as input to the generator.
 - **Expected generated files** (e.g. `MyCase.SourceText.g.cs`) the output to verify against.
-- **A JSON descriptor** (`MyCase.json`) maps the inputs and expected outputs (diagnostics coming soon(tm)):
+- **A JSON descriptor** (`MyCase.json`) maps the inputs, expected outputs, and any expected diagnostics:
 
 ```json
 {
@@ -36,6 +36,48 @@ A test case is three kinds of file in a `TestCases/` folder next to your test cl
 
 `SourceFileName` is the file on disk; `GeneratedFileName` is the **hint name** your generator passes to
 `context.AddSource(hintName, ...)`.
+
+## Expecting diagnostics
+
+Declare expected diagnostics where they occur:
+
+- On a **source file** or **generated file** entry, an `ExpectedDiagnostics` array asserts diagnostics located in
+  that file. Give each a location by `Snippet` (the start of its single occurrence in that file) or by an explicit
+  1-based `Line`/`Column`.
+- At the **top level**, an `ExpectedDiagnostics` array asserts diagnostics with no location (`Location.None`) — for
+  example `CS5001` or a compilation-level analyzer diagnostic.
+
+Each entry has an `Id`, an optional `Severity` (defaults to `Error`), and an optional `Message` to match exactly.
+
+```json
+{
+    "SourceFiles": [
+        {
+            "SourceFileName": "MyCase.Attribute.cs",
+            "ExpectedDiagnostics": [
+                { "Id": "CS0246", "Snippet": "CreateService<T>(" },
+                { "Id": "CS0246", "Line": 10, "Column": 17 }
+            ]
+        }
+    ],
+    "GeneratedFiles": [
+        {
+            "SourceFileName": "MyCase.SourceText.g.cs",
+            "GeneratedFileName": "MyNamespace.MyTypeSourceText.g.cs",
+            "ExpectedDiagnostics": [
+                { "Id": "CS0219", "Severity": "Warning", "Snippet": "unused" }
+            ]
+        }
+    ],
+    "ExpectedDiagnostics": [
+        { "Id": "CS5001" }
+    ]
+}
+```
+
+Only the diagnostic's **start** is asserted, so the reported span may extend past the located snippet. A snippet
+that is missing or appears more than once in its file fails the test with a helpful message — use a more specific
+snippet or an explicit `Line`/`Column`.
 
 ## Wiring the test
 

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/SourceGeneratorTestBuilder.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/SourceGeneratorTestBuilder.cs
@@ -393,6 +393,8 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
 
         test.TestState.GeneratedSources.AddRange(generatedFiles);
 
+        AddExpectedDiagnostics(test, testCase, sourceFiles, generatedFiles);
+
         foreach (var configure in this.configurations)
         {
             configure(test);
@@ -590,6 +592,129 @@ public sealed class SourceGeneratorTestBuilder<TSourceGenerator, TVerifier>
             / typeof(TSourceGenerator).Assembly.GetName().Name
             / typeof(TSourceGenerator).FullName
             / hintName;
+    }
+
+    private void AddExpectedDiagnostics(
+        CSharpSourceGeneratorTest<TSourceGenerator, TVerifier> test,
+        ITestCase testCase,
+        (string filename, SourceText content)[] sourceFiles,
+        (string filename, SourceText content)[] generatedFiles
+    )
+    {
+        // Locationless diagnostics declared at the top level (Location.None).
+        foreach (var expected in testCase.ExpectedDiagnostics)
+        {
+            test.TestState.ExpectedDiagnostics.Add(BuildLocationlessDiagnostic(expected, testCase));
+        }
+
+        // Diagnostics located within a specific input source file.
+        for (var i = 0; i < testCase.SourceFiles.Count; i++)
+        {
+            var (path, content) = sourceFiles[i];
+            foreach (var expected in testCase.SourceFiles[i].ExpectedDiagnostics)
+            {
+                test.TestState.ExpectedDiagnostics.Add(BuildLocatedDiagnostic(expected, testCase, path, content));
+            }
+        }
+
+        // Diagnostics located within a specific generated file's expected content.
+        for (var i = 0; i < testCase.GeneratedFiles.Count; i++)
+        {
+            var (path, content) = generatedFiles[i];
+            foreach (var expected in testCase.GeneratedFiles[i].ExpectedDiagnostics)
+            {
+                test.TestState.ExpectedDiagnostics.Add(BuildLocatedDiagnostic(expected, testCase, path, content));
+            }
+        }
+    }
+
+    private DiagnosticResult BuildLocationlessDiagnostic(TestExpectedDiagnostic expected, ITestCase testCase)
+    {
+        if (!string.IsNullOrEmpty(expected.Snippet) || expected.Line.HasValue || expected.Column.HasValue)
+        {
+            throw new InvalidOperationException(
+                $"Expected diagnostic '{expected.Id}' declared at the top level is locationless; declare it on a source or generated file to give it a Snippet or Line/Column."
+            );
+        }
+
+        var diagnostic = new DiagnosticResult(expected.Id, expected.Severity).WithNoLocation();
+        return ApplyMessage(diagnostic, expected, testCase);
+    }
+
+    private DiagnosticResult BuildLocatedDiagnostic(
+        TestExpectedDiagnostic expected,
+        ITestCase testCase,
+        string path,
+        SourceText content
+    )
+    {
+        var (line, column) = ResolveLocation(expected, path, content, testCase);
+
+        // WithLocation asserts the start position only (the framework ignores the span length), matching the
+        // "point at where the diagnostic starts" model the test case describes.
+        var diagnostic = new DiagnosticResult(expected.Id, expected.Severity).WithLocation(path, line, column);
+        return ApplyMessage(diagnostic, expected, testCase);
+    }
+
+    private DiagnosticResult ApplyMessage(
+        DiagnosticResult diagnostic,
+        TestExpectedDiagnostic expected,
+        ITestCase testCase
+    )
+    {
+        return expected.Message == null
+            ? diagnostic
+            : diagnostic.WithMessage(ExpandVariables(testCase, expected.Message));
+    }
+
+    private (int line, int column) ResolveLocation(
+        TestExpectedDiagnostic expected,
+        string path,
+        SourceText content,
+        ITestCase testCase
+    )
+    {
+        var hasSnippet = !string.IsNullOrEmpty(expected.Snippet);
+
+        if (hasSnippet && (expected.Line.HasValue || expected.Column.HasValue))
+        {
+            throw new InvalidOperationException(
+                $"Expected diagnostic '{expected.Id}' in '{path}' specifies both a Snippet and an explicit Line/Column; use one or the other."
+            );
+        }
+
+        if (!hasSnippet)
+        {
+            if (!expected.Line.HasValue || !expected.Column.HasValue)
+            {
+                throw new InvalidOperationException(
+                    $"Expected diagnostic '{expected.Id}' in '{path}' must specify either a Snippet or both Line and Column."
+                );
+            }
+
+            return (expected.Line.Value, expected.Column.Value);
+        }
+
+        var snippet = ExpandVariables(testCase, expected.Snippet!);
+        var text = content.ToString();
+
+        var index = text.IndexOf(snippet, StringComparison.Ordinal);
+        if (index < 0)
+        {
+            throw new InvalidOperationException(
+                $"Expected diagnostic '{expected.Id}' could not locate the snippet '{snippet}' in '{path}'."
+            );
+        }
+
+        if (text.IndexOf(snippet, index + 1, StringComparison.Ordinal) >= 0)
+        {
+            throw new InvalidOperationException(
+                $"Expected diagnostic '{expected.Id}' located the snippet '{snippet}' more than once in '{path}'; use a more specific snippet or an explicit Line/Column."
+            );
+        }
+
+        var position = content.Lines.GetLinePosition(index);
+        return (position.Line + 1, position.Character + 1);
     }
 
     private string ExpandVariables(ITestCase testCase, string text)

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestCase.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestCase.cs
@@ -45,6 +45,12 @@ public class TestCase : ITestCase
     /// <inheritdoc cref="ITestCase.GeneratedFiles"/>
     IReadOnlyList<TestGeneratedFile> ITestCase.GeneratedFiles => GeneratedFiles;
 
+    /// <inheritdoc cref="ITestCase.ExpectedDiagnostics"/>
+    public List<TestExpectedDiagnostic> ExpectedDiagnostics { get; set; } = [];
+
+    /// <inheritdoc cref="ITestCase.ExpectedDiagnostics"/>
+    IReadOnlyList<TestExpectedDiagnostic> ITestCase.ExpectedDiagnostics => ExpectedDiagnostics;
+
     /// <inheritdoc/>
     public string? Directory { get; set; }
 

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestExpectedDiagnostic.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestExpectedDiagnostic.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+
+namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
+
+/// <summary>
+///     Describes a diagnostic the test expects the compilation or generator to report. Where the diagnostic is
+///     declared determines its location: declared on <see cref="ITestCase.ExpectedDiagnostics" /> it is expected to
+///     have no location (<see cref="Location.None" />); declared on a <see cref="TestSourceFile" /> or
+///     <see cref="TestGeneratedFile" /> it is expected in that file, located by <see cref="Snippet" /> or by an
+///     explicit <see cref="Line" /> and <see cref="Column" />.
+/// </summary>
+public class TestExpectedDiagnostic
+{
+    /// <summary>
+    ///     The diagnostic id, for example a compiler code such as <c>"CS0246"</c> or a generator-authored id such as
+    ///     <c>"ZC1001"</c>.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     The severity of the diagnostic. Defaults to <see cref="DiagnosticSeverity.Error" />. In JSON this accepts the
+    ///     name of a <see cref="DiagnosticSeverity" /> value (for example <c>"Error"</c> or <c>"Warning"</c>).
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<DiagnosticSeverity>))]
+    public DiagnosticSeverity Severity { get; set; } = DiagnosticSeverity.Error;
+
+    /// <summary>
+    ///     A code snippet to locate within the containing file. The start of its single occurrence becomes the
+    ///     diagnostic location. Mutually exclusive with <see cref="Line" /> and <see cref="Column" />. Only applies when
+    ///     the diagnostic is declared on a <see cref="TestSourceFile" /> or <see cref="TestGeneratedFile" />.
+    /// </summary>
+    public string? Snippet { get; set; }
+
+    /// <summary>
+    ///     The explicit one-based start line of the diagnostic within the containing file, used instead of
+    ///     <see cref="Snippet" />. Must be paired with <see cref="Column" />.
+    /// </summary>
+    public int? Line { get; set; }
+
+    /// <summary>
+    ///     The explicit one-based start column of the diagnostic within the containing file, used instead of
+    ///     <see cref="Snippet" />. Must be paired with <see cref="Line" />.
+    /// </summary>
+    public int? Column { get; set; }
+
+    /// <summary>
+    ///     An optional exact message to assert against the reported diagnostic. When set, the reported message must
+    ///     equal this value (after <c>$(name)</c> variable expansion); when <see langword="null" /> the message is not
+    ///     verified.
+    /// </summary>
+    public string? Message { get; set; }
+}

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestGeneratedFile.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestGeneratedFile.cs
@@ -18,4 +18,10 @@ public class TestGeneratedFile
     ///     It is mapped to the full generated file path the test verifies against.
     /// </summary>
     public string GeneratedFileName { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     The diagnostics the test expects to be reported in this generated file, located within its expected content
+    ///     by <see cref="TestExpectedDiagnostic.Snippet" /> or by an explicit line and column.
+    /// </summary>
+    public List<TestExpectedDiagnostic> ExpectedDiagnostics { get; set; } = [];
 }

--- a/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestSourceFile.cs
+++ b/src/ZCrew.Extensions.CodeAnalysis.CSharp.Testing/TestSourceFile.cs
@@ -9,4 +9,10 @@ public class TestSourceFile
     ///     The file name of the source, resolved relative to <see cref="TestCase.Directory" />.
     /// </summary>
     public string SourceFileName { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     The diagnostics the test expects to be reported in this source file, located within it by
+    ///     <see cref="TestExpectedDiagnostic.Snippet" /> or by an explicit line and column.
+    /// </summary>
+    public List<TestExpectedDiagnostic> ExpectedDiagnostics { get; set; } = [];
 }

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/DiagnosticTests/DiagnosticTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/DiagnosticTests/DiagnosticTests.cs
@@ -1,0 +1,24 @@
+using ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests.TestHelpers;
+using ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
+
+namespace ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests.DiagnosticTests;
+
+public class DiagnosticTests
+{
+    private static readonly TestPath TestCases = TestPath.ForCaller() / "TestCases";
+
+    [Theory]
+    [InlineData("Undefined.json")]
+    public async Task ExpectedDiagnostics_ShouldMatchReportedDiagnostic(string testDescriptor)
+    {
+        // Arrange
+        var testCaseFile = TestCases / testDescriptor;
+        var testCase = await JsonTestCase.FromJsonFileAsync(testCaseFile, TestContext.Current.CancellationToken);
+
+        // Act
+        var test = await GeneratorTest.Baseline.BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/DiagnosticTests/TestCases/Undefined.Source.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/DiagnosticTests/TestCases/Undefined.Source.cs
@@ -1,0 +1,4 @@
+public class Sample
+{
+    public void Configure(Undefined service) { }
+}

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/DiagnosticTests/TestCases/Undefined.json
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.SourceGeneratorTests/DiagnosticTests/TestCases/Undefined.json
@@ -1,0 +1,14 @@
+{
+    "Description": "Asserts an expected compiler diagnostic located by a code snippet in a source file.",
+    "SourceFiles": [
+        {
+            "SourceFileName": "Undefined.Source.cs",
+            "ExpectedDiagnostics": [
+                {
+                    "Id": "CS0246",
+                    "Snippet": "Undefined"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests/JsonTestCaseTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests/JsonTestCaseTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using ZCrew.Extensions.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis;
 using ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests.TestDoubles;
 
 namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests;
@@ -13,6 +13,96 @@ public class JsonTestCaseTests
             "GeneratedFiles": [{ "SourceFileName": "Expected.g.cs", "GeneratedFileName": "Source.g.cs" }]
         }
         """;
+
+    private const string DiagnosticsJson = """
+        {
+            "SourceFiles": [
+                {
+                    "SourceFileName": "Source.cs",
+                    "ExpectedDiagnostics": [
+                        { "Id": "CS0246", "Snippet": "CreateService<T>(" }
+                    ]
+                }
+            ],
+            "GeneratedFiles": [
+                {
+                    "SourceFileName": "Expected.g.cs",
+                    "GeneratedFileName": "Source.g.cs",
+                    "ExpectedDiagnostics": [
+                        { "Id": "ZC1001", "Severity": "Warning", "Line": 10, "Column": 5, "Message": "not supported" }
+                    ]
+                }
+            ],
+            "ExpectedDiagnostics": [
+                { "Id": "CS5001" }
+            ]
+        }
+        """;
+
+    [Fact]
+    public void FromJsonFile_ShouldParseExpectedDiagnostics()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var file = temp.WriteFile("case.json", DiagnosticsJson);
+
+        // Act
+        var testCase = JsonTestCase.FromJsonFile(file);
+
+        // Assert — snippet diagnostic nested under the source file.
+        var snippetDiagnostic = Assert.Single(Assert.Single(testCase.SourceFiles).ExpectedDiagnostics);
+        Assert.Equal("CS0246", snippetDiagnostic.Id);
+        Assert.Equal("CreateService<T>(", snippetDiagnostic.Snippet);
+        // Severity defaults to Error when omitted; location fields stay null in snippet form.
+        Assert.Equal(DiagnosticSeverity.Error, snippetDiagnostic.Severity);
+        Assert.Null(snippetDiagnostic.Line);
+        Assert.Null(snippetDiagnostic.Column);
+        Assert.Null(snippetDiagnostic.Message);
+
+        // Explicit line/column diagnostic nested under the generated file.
+        var explicitDiagnostic = Assert.Single(Assert.Single(testCase.GeneratedFiles).ExpectedDiagnostics);
+        Assert.Equal("ZC1001", explicitDiagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Warning, explicitDiagnostic.Severity);
+        Assert.Equal(10, explicitDiagnostic.Line);
+        Assert.Equal(5, explicitDiagnostic.Column);
+        Assert.Equal("not supported", explicitDiagnostic.Message);
+
+        // Locationless diagnostic at the top level.
+        var locationlessDiagnostic = Assert.Single(testCase.ExpectedDiagnostics);
+        Assert.Equal("CS5001", locationlessDiagnostic.Id);
+        Assert.Null(locationlessDiagnostic.Snippet);
+        Assert.Null(locationlessDiagnostic.Line);
+    }
+
+    [Fact]
+    public void FromJsonFile_WithOmittedExpectedDiagnostics_ShouldDefaultToEmpty()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var file = temp.WriteFile("case.json", ValidJson);
+
+        // Act
+        var testCase = JsonTestCase.FromJsonFile(file);
+
+        // Assert — empty at the top level and on each file entry.
+        Assert.Empty(testCase.ExpectedDiagnostics);
+        Assert.Empty(Assert.Single(testCase.SourceFiles).ExpectedDiagnostics);
+        Assert.Empty(Assert.Single(testCase.GeneratedFiles).ExpectedDiagnostics);
+    }
+
+    [Fact]
+    public void FromJsonFile_ShouldNotLeakExpectedDiagnosticsIntoProperties()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var file = temp.WriteFile("case.json", DiagnosticsJson);
+
+        // Act
+        var testCase = JsonTestCase.FromJsonFile(file);
+
+        // Assert — a typed property binds the key, so it must not fall through to the extension-data bag.
+        Assert.DoesNotContain("ExpectedDiagnostics", ((ITestCase)testCase).Properties.Keys);
+    }
 
     [Fact]
     public void FromJsonFile_ShouldParseSourceAndGeneratedFiles()

--- a/tests/ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests/SourceGeneratorTestBuilderTests.cs
+++ b/tests/ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests/SourceGeneratorTestBuilderTests.cs
@@ -1,11 +1,37 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests.TestDoubles;
 
 namespace ZCrew.Extensions.CodeAnalysis.CSharp.Testing.UnitTests;
 
+[SuppressMessage("ReSharper", "AccessToDisposedClosure")]
 public class SourceGeneratorTestBuilderTests
 {
+    // A source whose newlines are explicit '\n' so line/column assertions do not depend on the file's line endings
+    private const string SnippetSource = "class Sample\n{\n    Undefined Value;\n}\n";
+
+    private static async Task<CSharpSourceGeneratorTest<EmptyGenerator, DefaultVerifier>> BuildWithSourceAsync(
+        TempDirectory temp,
+        string sourceContent,
+        TestExpectedDiagnostic expected,
+        string testName = "Test"
+    )
+    {
+        temp.WriteFile("Source.cs", sourceContent);
+        var testCase = new TestCase(testName)
+        {
+            Directory = temp.DirectoryPath,
+            SourceFiles = [new TestSourceFile { SourceFileName = "Source.cs", ExpectedDiagnostics = [expected] }],
+        };
+
+        return await SourceGeneratorTestBuilder<EmptyGenerator>
+            .Create()
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
+    }
+
     private static string ExpectedGeneratedPath<TGenerator>(string hintName)
     {
         return Path.Combine(typeof(TGenerator).Assembly.GetName().Name!, typeof(TGenerator).FullName!, hintName);
@@ -359,5 +385,279 @@ public class SourceGeneratorTestBuilderTests
 
         // Assert
         await Assert.ThrowsAnyAsync<OperationCanceledException>(act);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithSnippetDiagnostic_ShouldResolveStartLocation()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic { Id = "CS0246", Snippet = "Undefined" };
+
+        // Act
+        var test = await BuildWithSourceAsync(temp, SnippetSource, expected);
+
+        // Assert
+        var diagnostic = Assert.Single(test.TestState.ExpectedDiagnostics);
+        Assert.Equal("CS0246", diagnostic.Id);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        var location = Assert.Single(diagnostic.Spans);
+        Assert.Equal("Source.cs", location.Span.Path);
+        Assert.Equal(new LinePosition(2, 4), location.Span.StartLinePosition);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithExplicitLineColumn_ShouldUseGivenPosition()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic
+        {
+            Id = "CS0246",
+            Line = 3,
+            Column = 5,
+        };
+
+        // Act
+        var test = await BuildWithSourceAsync(temp, SnippetSource, expected);
+
+        // Assert
+        var diagnostic = Assert.Single(test.TestState.ExpectedDiagnostics);
+        var location = Assert.Single(diagnostic.Spans);
+        Assert.Equal("Source.cs", location.Span.Path);
+        // Line/Column are 1-based; the framework stores a 0-based LinePosition.
+        Assert.Equal(new LinePosition(2, 4), location.Span.StartLinePosition);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithSeverity_ShouldSetSeverity()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic
+        {
+            Id = "ZC1001",
+            Severity = DiagnosticSeverity.Warning,
+            Snippet = "Undefined",
+        };
+
+        // Act
+        var test = await BuildWithSourceAsync(temp, SnippetSource, expected);
+
+        // Assert
+        var diagnostic = Assert.Single(test.TestState.ExpectedDiagnostics);
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithDiagnosticMessage_ShouldExpandAndSetMessage()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic
+        {
+            Id = "CS0246",
+            Snippet = "Undefined",
+            Message = "issue in $(TestName)",
+        };
+
+        // Act
+        var test = await BuildWithSourceAsync(temp, SnippetSource, expected, testName: "MyTest");
+
+        // Assert
+        var diagnostic = Assert.Single(test.TestState.ExpectedDiagnostics);
+        Assert.Equal("issue in MyTest", diagnostic.Message);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithoutMessage_ShouldNotAssertMessage()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic { Id = "CS0246", Snippet = "Undefined" };
+
+        // Act
+        var test = await BuildWithSourceAsync(temp, SnippetSource, expected);
+
+        // Assert
+        var diagnostic = Assert.Single(test.TestState.ExpectedDiagnostics);
+        Assert.Null(diagnostic.Message);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithDiagnosticsOnMultipleFiles_ShouldScopeSnippetToContainingFile()
+    {
+        // Arrange — the same snippet appears in both files, so each resolves only within the file it is declared on.
+        using var temp = new TempDirectory();
+        temp.WriteFile("A.cs", "class A { Undefined X; }");
+        temp.WriteFile("B.cs", "class B { Undefined Y; }");
+        var testCase = new TestCase
+        {
+            Directory = temp.DirectoryPath,
+            SourceFiles =
+            [
+                new TestSourceFile
+                {
+                    SourceFileName = "A.cs",
+                    ExpectedDiagnostics = [new TestExpectedDiagnostic { Id = "CS0246", Snippet = "Undefined" }],
+                },
+                new TestSourceFile
+                {
+                    SourceFileName = "B.cs",
+                    ExpectedDiagnostics = [new TestExpectedDiagnostic { Id = "CS0103", Snippet = "Undefined" }],
+                },
+            ],
+        };
+
+        // Act
+        var test = await SourceGeneratorTestBuilder<EmptyGenerator>
+            .Create()
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert — each diagnostic points at its own file.
+        Assert.Equal(2, test.TestState.ExpectedDiagnostics.Count);
+        var fromA = test.TestState.ExpectedDiagnostics.Single(d => d.Id == "CS0246");
+        var fromB = test.TestState.ExpectedDiagnostics.Single(d => d.Id == "CS0103");
+        Assert.Equal("A.cs", Assert.Single(fromA.Spans).Span.Path);
+        Assert.Equal("B.cs", Assert.Single(fromB.Spans).Span.Path);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithGeneratedFileDiagnostic_ShouldResolveInGeneratedContent()
+    {
+        // Arrange — "Broken" is on line 2 (0-based 1), starting at char 12.
+        using var temp = new TempDirectory();
+        temp.WriteFile("Expected.g.cs", "// generated\nclass Gen { Broken X; }\n");
+        var testCase = new TestCase
+        {
+            Directory = temp.DirectoryPath,
+            GeneratedFiles =
+            [
+                new TestGeneratedFile
+                {
+                    SourceFileName = "Expected.g.cs",
+                    GeneratedFileName = "Gen.g.cs",
+                    ExpectedDiagnostics = [new TestExpectedDiagnostic { Id = "CS0246", Snippet = "Broken" }],
+                },
+            ],
+        };
+
+        // Act
+        var test = await SourceGeneratorTestBuilder<EmptyGenerator>
+            .Create()
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert — the location resolves against the generated file's resolved hint-name path.
+        var diagnostic = Assert.Single(test.TestState.ExpectedDiagnostics);
+        var location = Assert.Single(diagnostic.Spans);
+        Assert.Equal(ExpectedGeneratedPath<EmptyGenerator>("Gen.g.cs"), location.Span.Path);
+        Assert.Equal(new LinePosition(1, 12), location.Span.StartLinePosition);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithTopLevelDiagnostic_ShouldSetNoLocation()
+    {
+        // Arrange — a top-level diagnostic is locationless.
+        using var temp = new TempDirectory();
+        var testCase = new TestCase
+        {
+            Directory = temp.DirectoryPath,
+            ExpectedDiagnostics = [new TestExpectedDiagnostic { Id = "CS5001" }],
+        };
+
+        // Act
+        var test = await SourceGeneratorTestBuilder<EmptyGenerator>
+            .Create()
+            .BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert
+        var diagnostic = Assert.Single(test.TestState.ExpectedDiagnostics);
+        Assert.Equal("CS5001", diagnostic.Id);
+        Assert.Empty(diagnostic.Spans);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithTopLevelDiagnosticHavingLocation_ShouldThrow()
+    {
+        // Arrange — a top-level diagnostic must not carry a location.
+        using var temp = new TempDirectory();
+        var testCase = new TestCase
+        {
+            Directory = temp.DirectoryPath,
+            ExpectedDiagnostics = [new TestExpectedDiagnostic { Id = "CS0246", Snippet = "Undefined" }],
+        };
+
+        // Act
+        var act = async () =>
+            await SourceGeneratorTestBuilder<EmptyGenerator>
+                .Create()
+                .BuildAsync(testCase, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithSnippetNotFound_ShouldThrow()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic { Id = "CS0246", Snippet = "DoesNotExist" };
+
+        // Act
+        var act = async () => await BuildWithSourceAsync(temp, SnippetSource, expected);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Contains("DoesNotExist", exception.Message);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithAmbiguousSnippet_ShouldThrow()
+    {
+        // Arrange — "Value" occurs in both "Value1" and "Value2".
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic { Id = "CS0246", Snippet = "Value" };
+
+        // Act
+        var act = async () => await BuildWithSourceAsync(temp, "class A { int Value1; int Value2; }", expected);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Contains("more than once", exception.Message);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithSnippetAndExplicitLocation_ShouldThrow()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic
+        {
+            Id = "CS0246",
+            Snippet = "Undefined",
+            Line = 3,
+            Column = 5,
+        };
+
+        // Act
+        var act = async () => await BuildWithSourceAsync(temp, SnippetSource, expected);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithoutSnippetOrLocation_ShouldThrow()
+    {
+        // Arrange
+        using var temp = new TempDirectory();
+        var expected = new TestExpectedDiagnostic { Id = "CS0246" };
+
+        // Act
+        var act = async () => await BuildWithSourceAsync(temp, SnippetSource, expected);
+
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
     }
 }


### PR DESCRIPTION
Adds in expected diagnostics for tests. This can be applied on source files, generated files, or on no files (locationless)

The user can specify a line+column or a code snippet (to specify the start based on the first matching position of the snippet). Both of these options only work on source files or generated files.

Closes #31